### PR TITLE
z/OS response compatibility in ftpd#cmd.c

### DIFF
--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -2,8 +2,8 @@
 ** FTPD Command Parser & Dispatcher
 **
 ** FTP protocol command handling (client-facing).
-** Stub implementation for Step 1.2.
-** Full implementation in Step 1.3.
+** Response strings match z/OS FTP Server behavior
+** (see doc/ZOS_FTP_REFERENCE.md).
 */
 #include "ftpd.h"
 #include "ftpd#ses.h"
@@ -11,18 +11,240 @@
 #include "ftpd#dat.h"
 
 /* --------------------------------------------------------------------
-** Command dispatch -- minimal set for Step 1.2 testing
+** Helper: return human-readable name for the current TYPE setting.
+** Matches z/OS format: "Ascii NonPrint", "Image", "Ebcdic NonPrint".
+** ----------------------------------------------------------------- */
+static const char *
+type_name(char t)
+{
+    switch (t) {
+    case XFER_TYPE_A: return "Ascii NonPrint";
+    case XFER_TYPE_I: return "Image";
+    case XFER_TYPE_E: return "Ebcdic NonPrint";
+    default:          return "Ascii NonPrint";
+    }
+}
+
+/* --------------------------------------------------------------------
+** Helper: return human-readable name for the current STRU setting.
+** Matches z/OS format: "File", "Record".
+** ----------------------------------------------------------------- */
+static const char *
+stru_name(char s)
+{
+    switch (s) {
+    case XFER_STRU_F: return "File";
+    case XFER_STRU_R: return "Record";
+    default:          return "File";
+    }
+}
+
+/* --------------------------------------------------------------------
+** cmd_syst -- SYST: mode-aware system identification
+** ----------------------------------------------------------------- */
+static int
+cmd_syst(ftpd_session_t *sess)
+{
+    if (sess->fsmode == FS_UFS) {
+        ftpd_session_reply(sess, FTP_215,
+            "UNIX is the operating system of this server. "
+            "FTP Server is running on MVS.");
+    } else {
+        ftpd_session_reply(sess, FTP_215,
+            "MVS is the operating system of this server. "
+            "FTP Server is running on MVS.");
+    }
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_feat -- FEAT: feature list (RFC 2389)
+** ----------------------------------------------------------------- */
+static int
+cmd_feat(ftpd_session_t *sess)
+{
+    char buf[256];
+    int len, i;
+    len = snprintf(buf, sizeof(buf),
+        "211-Features supported\r\n"
+        " SIZE\r\n"
+        " MDTM\r\n"
+        " SITE FILETYPE\r\n"
+        " SITE JES\r\n"
+        " UTF8\r\n"
+        "211 End\r\n");
+    for (i = 0; i < len; i++)
+        buf[i] = ebc2asc[(unsigned char)buf[i]];
+    send(sess->ctrl_sock, buf, len, 0);
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_help -- HELP: list supported commands
+** ----------------------------------------------------------------- */
+static int
+cmd_help(ftpd_session_t *sess)
+{
+    ftpd_session_reply_multi(sess, FTP_214,
+        "The following commands are recognized:",
+        "HELP command successful.");
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_noop -- NOOP
+** ----------------------------------------------------------------- */
+static int
+cmd_noop(ftpd_session_t *sess)
+{
+    ftpd_session_reply(sess, FTP_200, "OK");
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_stat -- STAT: server status
+** ----------------------------------------------------------------- */
+static int
+cmd_stat(ftpd_session_t *sess)
+{
+    ftpd_session_reply(sess, FTP_211, "%s", FTPD_VERSION_STR);
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_quit -- QUIT
+** ----------------------------------------------------------------- */
+static int
+cmd_quit(ftpd_session_t *sess)
+{
+    ftpd_session_reply(sess, FTP_221,
+                       "Quit command received. Goodbye.");
+    sess->state = SESS_CLOSING;
+    return -1;
+}
+
+/* --------------------------------------------------------------------
+** cmd_type -- TYPE: set transfer type (z/OS response format)
+** ----------------------------------------------------------------- */
+static int
+cmd_type(ftpd_session_t *sess, const char *arg)
+{
+    char t;
+    char first[64];
+    char last[64];
+
+    if (!arg[0]) {
+        snprintf(last, sizeof(last), "Type remains %s",
+                 type_name(sess->type));
+        ftpd_session_reply_multi(sess, FTP_501,
+            "missing type parameter", last);
+        return 0;
+    }
+
+    t = (char)toupper((unsigned char)arg[0]);
+
+    if (t == 'A') {
+        sess->type = XFER_TYPE_A;
+        ftpd_session_reply(sess, FTP_200,
+                           "Representation type is Ascii NonPrint");
+    }
+    else if (t == 'I') {
+        sess->type = XFER_TYPE_I;
+        ftpd_session_reply(sess, FTP_200,
+                           "Representation type is Image");
+    }
+    else if (t == 'E') {
+        /* Check for unsupported format parameter (e.g. TYPE E T) */
+        const char *p = arg + 1;
+        while (*p == ' ') p++;
+        if (*p && toupper((unsigned char)*p) != 'N') {
+            snprintf(first, sizeof(first),
+                     "TYPE has unsupported format %c",
+                     (char)toupper((unsigned char)*p));
+            snprintf(last, sizeof(last), "Type remains %s",
+                     type_name(sess->type));
+            ftpd_session_reply_multi(sess, FTP_504, first, last);
+            return 0;
+        }
+        sess->type = XFER_TYPE_E;
+        ftpd_session_reply(sess, FTP_200,
+                           "Representation type is Ebcdic NonPrint");
+    }
+    else if (t == 'L') {
+        /* TYPE L 8 is treated as Image (z/OS behavior) */
+        const char *p = arg + 1;
+        while (*p == ' ') p++;
+        if (*p == '8') {
+            sess->type = XFER_TYPE_I;
+            ftpd_session_reply(sess, FTP_200,
+                "Local byte 8, representation type is Image");
+        } else {
+            snprintf(first, sizeof(first), "unknown type  L %s", p);
+            snprintf(last, sizeof(last), "Type remains %s",
+                     type_name(sess->type));
+            ftpd_session_reply_multi(sess, FTP_501, first, last);
+        }
+    }
+    else {
+        snprintf(first, sizeof(first), "unknown type  %c", t);
+        snprintf(last, sizeof(last), "Type remains %s",
+                 type_name(sess->type));
+        ftpd_session_reply_multi(sess, FTP_501, first, last);
+    }
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_stru -- STRU: set file structure (z/OS response format)
+** ----------------------------------------------------------------- */
+static int
+cmd_stru(ftpd_session_t *sess, const char *arg)
+{
+    char s = (char)toupper((unsigned char)arg[0]);
+    char first[64];
+    char last[64];
+
+    if (s == 'F') {
+        sess->stru = XFER_STRU_F;
+        ftpd_session_reply(sess, FTP_250, "Data structure is File");
+    }
+    else if (s == 'R') {
+        sess->stru = XFER_STRU_R;
+        ftpd_session_reply(sess, FTP_250, "Data structure is Record");
+    }
+    else if (s == 'P') {
+        snprintf(last, sizeof(last), "Data structure remains %s",
+                 stru_name(sess->stru));
+        ftpd_session_reply_multi(sess, FTP_504,
+            "Page structure not implemented", last);
+    }
+    else {
+        snprintf(first, sizeof(first), "Unknown structure %c", s);
+        snprintf(last, sizeof(last), "Data structure remains %s",
+                 stru_name(sess->stru));
+        ftpd_session_reply_multi(sess, FTP_504, first, last);
+    }
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** Command dispatch
 ** ----------------------------------------------------------------- */
 int
 ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
 {
-    /* Before authentication: only USER, PASS, QUIT, HELP */
+    /* ----------------------------------------------------------------
+    ** Pre-authentication: allow informational commands per z/OS
+    ** behavior (ZOS_FTP_REFERENCE.md section 12).
+    ** USER, PASS, QUIT, SYST, FEAT, HELP, NOOP, STAT are allowed.
+    ** All others require authentication.
+    ** ---------------------------------------------------------------- */
     if (!sess->authenticated) {
         if (strcmp(cmd, "USER") == 0) {
             strncpy(sess->user, arg, sizeof(sess->user) - 1);
             sess->state = SESS_AUTH_PASS;
             ftpd_session_reply(sess, FTP_331,
-                               "User name okay, need password");
+                               "Send password please.");
             return 0;
         }
         if (strcmp(cmd, "PASS") == 0) {
@@ -32,87 +254,55 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
             strcat(sess->hlq, ".");
             strcpy(sess->mvs_cwd, sess->hlq);
             sess->state = SESS_READY;
-            ftpd_session_reply(sess, FTP_230, "User %s logged in",
-                               sess->user);
+            ftpd_session_reply(sess, FTP_230,
+                "%s is logged on.  Working directory is \"%s\".",
+                sess->user, sess->hlq);
             ftpd_log(LOG_INFO, "%s: User %s logged in", __func__,
                      sess->user);
             return 0;
         }
-        if (strcmp(cmd, "QUIT") == 0) {
-            ftpd_session_reply(sess, FTP_221, "Goodbye");
-            sess->state = SESS_CLOSING;
-            return -1;
-        }
-        ftpd_session_reply(sess, FTP_530, "Not logged in");
+        /* Pre-auth allowlist (z/OS compatible) */
+        if (strcmp(cmd, "QUIT") == 0) return cmd_quit(sess);
+        if (strcmp(cmd, "SYST") == 0) return cmd_syst(sess);
+        if (strcmp(cmd, "FEAT") == 0) return cmd_feat(sess);
+        if (strcmp(cmd, "HELP") == 0) return cmd_help(sess);
+        if (strcmp(cmd, "NOOP") == 0) return cmd_noop(sess);
+        if (strcmp(cmd, "STAT") == 0) return cmd_stat(sess);
+
+        ftpd_session_reply(sess, FTP_530, "Not logged in.");
         return 0;
     }
 
-    /* Authenticated commands */
-    if (strcmp(cmd, "QUIT") == 0) {
-        ftpd_session_reply(sess, FTP_221, "Goodbye");
-        sess->state = SESS_CLOSING;
-        return -1;
-    }
-    if (strcmp(cmd, "SYST") == 0) {
-        ftpd_session_reply(sess, FTP_215,
-                           "MVS is the operating system");
-        return 0;
-    }
-    if (strcmp(cmd, "NOOP") == 0) {
-        ftpd_session_reply(sess, FTP_200, "Command okay");
-        return 0;
-    }
-    if (strcmp(cmd, "TYPE") == 0) {
-        if (arg[0] == 'A' || arg[0] == 'a') {
-            sess->type = XFER_TYPE_A;
-            ftpd_session_reply(sess, FTP_200, "Type set to A");
-        }
-        else if (arg[0] == 'I' || arg[0] == 'i') {
-            sess->type = XFER_TYPE_I;
-            ftpd_session_reply(sess, FTP_200, "Type set to I");
-        }
-        else if (arg[0] == 'E' || arg[0] == 'e') {
-            sess->type = XFER_TYPE_E;
-            ftpd_session_reply(sess, FTP_200, "Type set to E");
-        }
-        else {
-            ftpd_session_reply(sess, FTP_504,
-                               "Type not implemented for that parameter");
-        }
-        return 0;
-    }
+    /* ----------------------------------------------------------------
+    ** Authenticated commands
+    ** ---------------------------------------------------------------- */
+    if (strcmp(cmd, "QUIT") == 0) return cmd_quit(sess);
+    if (strcmp(cmd, "SYST") == 0) return cmd_syst(sess);
+    if (strcmp(cmd, "NOOP") == 0) return cmd_noop(sess);
+    if (strcmp(cmd, "FEAT") == 0) return cmd_feat(sess);
+    if (strcmp(cmd, "HELP") == 0) return cmd_help(sess);
+    if (strcmp(cmd, "STAT") == 0) return cmd_stat(sess);
+    if (strcmp(cmd, "TYPE") == 0) return cmd_type(sess, arg);
+    if (strcmp(cmd, "STRU") == 0) return cmd_stru(sess, arg);
+
     if (strcmp(cmd, "MODE") == 0) {
         if (arg[0] == 'S' || arg[0] == 's') {
-            ftpd_session_reply(sess, FTP_200, "Mode set to S");
+            ftpd_session_reply(sess, FTP_200,
+                               "Data transfer mode is Stream");
         } else {
             ftpd_session_reply(sess, FTP_504,
                                "Only stream mode supported");
         }
         return 0;
     }
-    if (strcmp(cmd, "STRU") == 0) {
-        if (arg[0] == 'F' || arg[0] == 'f') {
-            sess->stru = XFER_STRU_F;
-            ftpd_session_reply(sess, FTP_200, "Structure set to F");
-        }
-        else if (arg[0] == 'R' || arg[0] == 'r') {
-            sess->stru = XFER_STRU_R;
-            ftpd_session_reply(sess, FTP_200, "Structure set to R");
-        }
-        else {
-            ftpd_session_reply(sess, FTP_504,
-                               "Structure not implemented for that parameter");
-        }
-        return 0;
-    }
     if (strcmp(cmd, "PWD") == 0 || strcmp(cmd, "XPWD") == 0) {
         if (sess->fsmode == FS_MVS) {
             ftpd_session_reply(sess, FTP_257,
-                               "\"'%s'\" is working directory",
+                               "\"'%s'\" is working directory.",
                                sess->mvs_cwd);
         } else {
             ftpd_session_reply(sess, FTP_257,
-                               "\"%s\" is working directory",
+                               "\"%s\" is the HFS working directory.",
                                sess->ufs_cwd);
         }
         return 0;
@@ -131,33 +321,6 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
             ftpd_session_reply(sess, FTP_425,
                                "Cannot open passive connection");
         }
-        return 0;
-    }
-    if (strcmp(cmd, "FEAT") == 0) {
-        char buf[256];
-        int len, i;
-        len = snprintf(buf, sizeof(buf),
-            "211-Features supported\r\n"
-            " SIZE\r\n"
-            " MDTM\r\n"
-            " REST STREAM\r\n"
-            " SITE FILETYPE\r\n"
-            " SITE JES\r\n"
-            " UTF8\r\n"
-            "211 End\r\n");
-        for (i = 0; i < len; i++)
-            buf[i] = ebc2asc[(unsigned char)buf[i]];
-        send(sess->ctrl_sock, buf, len, 0);
-        return 0;
-    }
-    if (strcmp(cmd, "HELP") == 0) {
-        ftpd_session_reply_multi(sess, FTP_214,
-            "The following commands are recognized:",
-            "HELP command complete");
-        return 0;
-    }
-    if (strcmp(cmd, "STAT") == 0) {
-        ftpd_session_reply(sess, FTP_211, "%s", FTPD_VERSION_STR);
         return 0;
     }
     if (strcmp(cmd, "ABOR") == 0) {
@@ -181,7 +344,6 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
     }
 
     /* Unknown command */
-    ftpd_session_reply(sess, FTP_500,
-                       "Syntax error, unrecognized command");
+    ftpd_session_reply(sess, FTP_500, "unknown command %s", cmd);
     return 0;
 }


### PR DESCRIPTION
## Summary

- Pre-auth allowlist: SYST, FEAT, HELP, NOOP, STAT, QUIT allowed before USER/PASS
- SYST mode-aware response based on `sess->fsmode` (MVS vs UNIX)
- FEAT: removed REST STREAM from feature list
- TYPE: z/OS format responses, TYPE L 8 support, multiline errors
- STRU: response code 250, multiline errors for unsupported structures
- Updated response strings (NOOP, QUIT, PWD, HELP, unknown command)
- Refactored shared commands into static functions (no pre-auth/post-auth duplication)

Fixes #9