### PR TITLE
fix: prevent immediate 421 idle timeout after login

### DIFF
--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -57,6 +57,9 @@ struct ftpd_session {
     char            cmd[FTPD_MAX_CMD_LEN]; /* current command line   */
     int             cmdlen;         /* command length                 */
 
+    /* Idle tracking (heap — immune to SVC stack corruption) */
+    time_t          idle_start;     /* getline idle timer start       */
+
     /* Statistics */
     long            bytes_sent;
     long            bytes_recv;

--- a/src/ftpd#cfg.c
+++ b/src/ftpd#cfg.c
@@ -171,6 +171,11 @@ parse_keyvalue(ftpd_config_t *cfg, const char *key, const char *value)
     }
     else if (strcmp(key, "IDLETIMEOUT") == 0) {
         cfg->idle_timeout = atoi(value);
+        if (cfg->idle_timeout <= 0) {
+            ftpd_log(LOG_WARN, "%s: IDLETIMEOUT must be > 0, using 300",
+                     __func__);
+            cfg->idle_timeout = 300;
+        }
     }
     else if (strcmp(key, "BANNER") == 0) {
         strncpy(cfg->banner, value, sizeof(cfg->banner) - 1);

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -148,20 +148,27 @@ ftpd_session_getline(ftpd_session_t *sess)
 {
     unsigned char c;
     int rc;
+    int idle_timeout;
+    time_t now;
     fd_set rfds;
     struct timeval tv;
-    time_t start;
-    time_t now;
 
     sess->cmdlen = 0;
     memset(sess->cmd, 0, sizeof(sess->cmd));
 
-    time(&start);
+    idle_timeout = sess->server->config.idle_timeout;
+    if (idle_timeout <= 0)
+        idle_timeout = 300;
+
+    /* Idle start lives in the session struct (heap) — immune to
+    ** stack corruption caused by select()/SVC 75.
+    */
+    sess->idle_start = time(NULL);
 
     while (sess->cmdlen < FTPD_MAX_CMD_LEN - 1) {
         /* Short select timeout — poll every 5 seconds so we can
         ** check the shutdown flag.  The real idle timeout is
-        ** measured cumulatively via start/now.
+        ** measured cumulatively via idle_start/now.
         */
         FD_ZERO(&rfds);
         FD_SET(sess->ctrl_sock, &rfds);
@@ -177,8 +184,9 @@ ftpd_session_getline(ftpd_session_t *sess)
             if (sess->server->flags & FTPD_QUIESCE)
                 return -1;
 
-            time(&now);
-            if ((now - start) >= sess->server->config.idle_timeout) {
+            now = time(NULL);
+            if (now > sess->idle_start &&
+                (now - sess->idle_start) >= (time_t)idle_timeout) {
                 ftpd_session_reply(sess, FTP_421,
                                    "Idle timeout, closing connection");
                 return -1;


### PR DESCRIPTION
## Summary

- Guard against `idle_timeout == 0` in `ftpd_session_getline()` — floor to 300s
- Add `now > start` guard to prevent unsigned arithmetic edge cases
- Validate `IDLETIMEOUT` in config parser: reject `<= 0`, warn and default to 300

## Root cause

The idle timeout comparison `(now - start) >= idle_timeout` uses `time_t` (unsigned long). If `idle_timeout` was 0 (e.g. from missing/malformed config before #12 fix), the condition `any_unsigned >= 0` is always true, causing an immediate 421 disconnect on the first select() timeout.

## Test plan

- [ ] `make build` compiles without errors
- [ ] Connect with FTP client, login — session stays alive waiting for commands
- [ ] Set `IDLETIMEOUT=30` in config, verify timeout fires after ~30s of inactivity
- [ ] Omit `IDLETIMEOUT` from config, verify default 300s applies

Fixes #13