### PR TITLE
feat: RAKF authentication via ftpd#aut.c

### DIFF
--- a/include/ftpd#aut.h
+++ b/include/ftpd#aut.h
@@ -1,0 +1,22 @@
+#ifndef FTPD_AUT_H
+#define FTPD_AUT_H
+/*
+** FTPD Authentication via RAKF (crent370 racf module)
+*/
+
+/*
+** Authenticate user via RAKF.
+** Called from the PASS command handler.
+**
+** - Calls racf_login() to verify userid/password
+** - Checks FACILITY class resource FTPAUTH for authorization
+** - Sets session state (authenticated, hlq, mvs_cwd, acee)
+** - Sends FTP reply (230 on success, 530 on failure)
+** - After 3 failed attempts, closes the connection
+**
+** Returns 0 to continue the session, -1 to close it.
+*/
+int ftpd_auth_pass(ftpd_session_t *sess, const char *password)
+                                                    asm("FTPAUTPS");
+
+#endif /* FTPD_AUT_H */

--- a/project.toml
+++ b/project.toml
@@ -48,6 +48,7 @@ options = ["SIZE=(4000K,40K)", "LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "FTPD",
+  "FTPD#AUT",
   "FTPD#CFG",
   "FTPD#CMD",
   "FTPD#CON",

--- a/src/ftpd#aut.c
+++ b/src/ftpd#aut.c
@@ -1,0 +1,119 @@
+/*
+** FTPD Authentication
+**
+** RAKF-based authentication via crent370 racf module.
+** Verifies userid/password and checks FACILITY class FTPAUTH.
+** When INSECURE=1, authentication is bypassed (any password accepted).
+*/
+#include "ftpd.h"
+#include "ftpd#ses.h"
+#include "ftpd#aut.h"
+
+#define FTPD_MAX_AUTH_ATTEMPTS  3
+#define FTPD_FACILITY_RESOURCE  "FTPAUTH"
+#define FTPD_FACILITY_CLASS     "FACILITY"
+
+/* --------------------------------------------------------------------
+** Authenticate via RAKF and set up session.
+** ----------------------------------------------------------------- */
+int
+ftpd_auth_pass(ftpd_session_t *sess, const char *password)
+{
+    ACEE *acee;
+    int racf_rc;
+    char user[9];
+    char pass[9];
+
+    /* Uppercase userid and password (RAKF requires uppercase) */
+    {
+        int i;
+        for (i = 0; i < 8 && sess->user[i]; i++)
+            user[i] = (char)toupper((unsigned char)sess->user[i]);
+        user[i] = '\0';
+
+        for (i = 0; i < 8 && password[i]; i++)
+            pass[i] = (char)toupper((unsigned char)password[i]);
+        pass[i] = '\0';
+    }
+
+    /* INSECURE mode: skip RAKF, accept any password */
+    if (sess->server->config.insecure) {
+        ftpd_log(LOG_WARN, "%s: INSECURE mode, skipping RAKF for %s",
+                 __func__, user);
+        goto accept;
+    }
+
+    /* Verify credentials via RAKF */
+    racf_rc = 0;
+    acee = racf_login(user, pass, NULL, &racf_rc);
+
+    /* Clear password from stack immediately */
+    memset(pass, 0, sizeof(pass));
+
+    if (!acee) {
+        sess->auth_attempts++;
+        ftpd_log(LOG_WARN, "%s: RAKF login failed for %s, rc=%d "
+                 "(attempt %d/%d)", __func__, user, racf_rc,
+                 sess->auth_attempts, FTPD_MAX_AUTH_ATTEMPTS);
+
+        if (sess->auth_attempts >= FTPD_MAX_AUTH_ATTEMPTS) {
+            ftpd_session_reply(sess, FTP_530,
+                "Login incorrect. Too many attempts, disconnecting.");
+            return -1;
+        }
+
+        ftpd_session_reply(sess, FTP_530, "Login incorrect.");
+        sess->state = SESS_AUTH_USER;
+        return 0;
+    }
+
+    /* Check FACILITY class authorization */
+    if (racf_auth(acee, FTPD_FACILITY_CLASS, FTPD_FACILITY_RESOURCE,
+                  RACF_ATTR_READ) != 0) {
+        ftpd_log(LOG_WARN, "%s: %s not authorized for %s.%s",
+                 __func__, user, FTPD_FACILITY_CLASS,
+                 FTPD_FACILITY_RESOURCE);
+        racf_logout(&acee);
+
+        sess->auth_attempts++;
+        if (sess->auth_attempts >= FTPD_MAX_AUTH_ATTEMPTS) {
+            ftpd_session_reply(sess, FTP_530,
+                "Not authorized for FTP access. Disconnecting.");
+            return -1;
+        }
+
+        ftpd_session_reply(sess, FTP_530,
+            "Not authorized for FTP access.");
+        sess->state = SESS_AUTH_USER;
+        return 0;
+    }
+
+    /* Store ACEE in session */
+    sess->acee = acee;
+
+accept:
+    /* Clear password from stack */
+    memset(pass, 0, sizeof(pass));
+
+    sess->authenticated = 1;
+    sess->auth_attempts = 0;
+
+    /* Set working directory to user's HLQ */
+    strcpy(sess->hlq, user);
+    strcat(sess->hlq, ".");
+    strcpy(sess->mvs_cwd, sess->hlq);
+
+    /* Also store uppercased userid */
+    strcpy(sess->user, user);
+
+    sess->state = SESS_READY;
+
+    ftpd_session_reply(sess, FTP_230,
+        "%s is logged on.  Working directory is \"%s\".",
+        sess->user, sess->hlq);
+
+    ftpd_log(LOG_INFO, "%s: %s logged in%s", __func__, user,
+             sess->server->config.insecure ? " (INSECURE)" : "");
+
+    return 0;
+}

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -9,6 +9,7 @@
 #include "ftpd#ses.h"
 #include "ftpd#cmd.h"
 #include "ftpd#dat.h"
+#include "ftpd#aut.h"
 
 /* --------------------------------------------------------------------
 ** Helper: return human-readable name for the current TYPE setting.
@@ -248,18 +249,7 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
             return 0;
         }
         if (strcmp(cmd, "PASS") == 0) {
-            /* Stub: accept any password for now */
-            sess->authenticated = 1;
-            strcpy(sess->hlq, sess->user);
-            strcat(sess->hlq, ".");
-            strcpy(sess->mvs_cwd, sess->hlq);
-            sess->state = SESS_READY;
-            ftpd_session_reply(sess, FTP_230,
-                "%s is logged on.  Working directory is \"%s\".",
-                sess->user, sess->hlq);
-            ftpd_log(LOG_INFO, "%s: User %s logged in", __func__,
-                     sess->user);
-            return 0;
+            return ftpd_auth_pass(sess, arg);
         }
         /* Pre-auth allowlist (z/OS compatible) */
         if (strcmp(cmd, "QUIT") == 0) return cmd_quit(sess);


### PR DESCRIPTION
## Summary

- New module `ftpd#aut.c` / `ftpd#aut.h` for RAKF-based authentication
- `racf_login()` verifies userid/password via SVC 244
- `racf_auth()` checks FACILITY class resource `FTPAUTH`
- 3 failed login attempts closes the connection
- `INSECURE=1` in config bypasses RAKF (for testing without RAKF)
- ACEE stored in session, cleaned up via `racf_logout()` in `session_free()`
- Password zeroed from stack after use
- Replaces the PASS stub in `ftpd#cmd.c`
- Added `FTPD#AUT` to link module include list

## Test plan

- [ ] `make build` + `make link` succeeds
- [ ] Login with valid RAKF credentials → 230 logged in
- [ ] Login with wrong password → 530 login incorrect
- [ ] 3 wrong attempts → connection closed
- [ ] User without FTPAUTH FACILITY access → 530 not authorized
- [ ] `INSECURE=1` in config → any password accepted

Fixes #10