### PR TITLE
Phase 3a: UFSD client integration

### DIFF
--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -5,6 +5,9 @@
 */
 #include "ftpd#xlt.h"
 
+/* Forward declaration — full definition in libufs.h */
+struct libufs_ufs;
+
 /* --- Session structure --- */
 struct ftpd_session {
     char            eye[8];         /* eye catcher                   */
@@ -41,6 +44,7 @@ struct ftpd_session {
     char            pds_name[45];   /* PDS dataset name when in_pds  */
 
     /* UFS context */
+    struct libufs_ufs *ufs;         /* UFSD session handle (lazy)    */
     char            ufs_cwd[256];   /* current UFS path              */
 
     /* JES context */

--- a/include/ftpd#ufs.h
+++ b/include/ftpd#ufs.h
@@ -1,0 +1,67 @@
+#ifndef FTPD_UFS_H
+#define FTPD_UFS_H
+/*
+** FTPD UFS Operations — UFSD Client Integration
+**
+** Wrapper layer around the UFSD client library (libufs).
+** UFSD is a soft dependency: if not running, all UFS commands
+** return 550.  Availability is detected lazily per session.
+**
+** Reference: mvsmf/src/ussapi.c (uss_get_ufs pattern)
+**
+** Codepage note: UFS stores files in IBM-1047, not CP037.
+** Text translation uses ftpd_xlat_a2e/e2a (IBM-1047 tables),
+** NOT ftpd_xlat_mvs_a2e/e2a (CP037 — those are for MVS datasets).
+*/
+
+/*
+** Get per-session UFS handle (lazy init).
+** On first call: ufsnew() + ufs_setuser().
+** Returns handle on success, NULL if UFSD not running.
+** Sends 550 reply on failure.
+*/
+struct libufs_ufs *ftpd_ufs_get(ftpd_session_t *sess)      asm("FTPUFGET");
+
+/*
+** Free per-session UFS handle.
+** Called from ftpd_session_free().  Safe to call with NULL handle.
+*/
+void ftpd_ufs_free(ftpd_session_t *sess)                   asm("FTPUFFRE");
+
+/*
+** Map UFSD return code to FTP reply code.
+*/
+int ftpd_ufs_rc_to_ftp(int ufsd_rc)                        asm("FTPUFRC");
+
+/*
+** Get human-readable error message for UFSD return code.
+*/
+const char *ftpd_ufs_rc_message(int ufsd_rc)                asm("FTPUFMSG");
+
+/*
+** Send FTP error reply for a UFSD return code.
+** Maps RC to FTP code + message, sends via ftpd_session_reply().
+*/
+void ftpd_ufs_error(ftpd_session_t *sess, int ufsd_rc)     asm("FTPUFERR");
+
+/*
+** Resolve a path argument against the session's UFS CWD.
+** Handles relative paths, ".", "..", absolute paths.
+** Prevents traversal above UFS root "/".
+** Returns 0 on success (result in out), -1 on error.
+*/
+int ftpd_ufs_resolve(ftpd_session_t *sess, const char *arg,
+                     char *out, int outlen)                 asm("FTPUFRES");
+
+/*
+** CWD — change UFS working directory.
+** Validates path via ufs_chgdir(), updates sess->ufs_cwd.
+*/
+int ftpd_ufs_cwd(ftpd_session_t *sess, const char *arg)    asm("FTPUFCWD");
+
+/*
+** CDUP — move to parent directory in UFS.
+*/
+int ftpd_ufs_cdup(ftpd_session_t *sess)                    asm("FTPUFCDU");
+
+#endif /* FTPD_UFS_H */

--- a/project.toml
+++ b/project.toml
@@ -40,6 +40,7 @@ space = ["TRK", 10, 5, 5]
 
 [dependencies]
 "mvslovers/crent370" = ">=1.0.7"
+"mvslovers/ufsd" = "=1.0.0-dev"
 
 [[link.module]]
 name = "FTPD"
@@ -58,9 +59,13 @@ include = [
   "FTPD#MVS",
   "FTPD#SES",
   "FTPD#SIT",
+  "FTPD#UFS",
   "FTPD#XLT",
 ]
 setcode = "AC(1)"
+
+[link.module.dep_includes]
+"mvslovers/ufsd" = "*"
 
 [release]
 version_files = ["VERSION"]

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -11,6 +11,7 @@
 #include "ftpd#dat.h"
 #include "ftpd#aut.h"
 #include "ftpd#mvs.h"
+#include "ftpd#ufs.h"
 #include "ftpd#jes.h"
 #include "ftpd#sit.h"
 
@@ -327,11 +328,22 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         return 0;
     }
     if (strcmp(cmd, "CWD") == 0 || strcmp(cmd, "XCWD") == 0) {
-        if (sess->fsmode == FS_MVS) {
-            return ftpd_mvs_cwd(sess, arg);
+        // Mode switching: CWD /... → UFS, CWD 'DSN' → MVS
+        if (arg[0] == '/') {
+            // Switch to UFS mode
+            sess->fsmode = FS_UFS;
+            return ftpd_ufs_cwd(sess, arg);
         }
-        ftpd_session_reply(sess, FTP_502, "CWD not implemented for UFS");
-        return 0;
+        if (sess->fsmode == FS_UFS) {
+            // Quoted name while in UFS → switch back to MVS
+            if (arg[0] == '\'') {
+                sess->fsmode = FS_MVS;
+                return ftpd_mvs_cwd(sess, arg);
+            }
+            // Relative navigation within UFS
+            return ftpd_ufs_cwd(sess, arg);
+        }
+        return ftpd_mvs_cwd(sess, arg);
     }
     if (strcmp(cmd, "LIST") == 0) {
         if (sess->filetype == FT_JES)
@@ -363,10 +375,9 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         return 0;
     }
     if (strcmp(cmd, "CDUP") == 0 || strcmp(cmd, "XCUP") == 0) {
-        if (sess->fsmode == FS_MVS)
-            return ftpd_mvs_cdup(sess);
-        ftpd_session_reply(sess, FTP_502, "CDUP not implemented for UFS");
-        return 0;
+        if (sess->fsmode == FS_UFS)
+            return ftpd_ufs_cdup(sess);
+        return ftpd_mvs_cdup(sess);
     }
     if (strcmp(cmd, "RETR") == 0) {
         if (sess->filetype == FT_JES)

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -7,6 +7,7 @@
 #include "ftpd.h"
 #include "ftpd#ses.h"
 #include "ftpd#cmd.h"
+#include "ftpd#ufs.h"
 
 /* --------------------------------------------------------------------
 ** Allocate and initialize a new session
@@ -36,6 +37,8 @@ ftpd_session_new(ftpd_server_t *server, int sock)
     sess->auth_attempts = 0;
     sess->acee = NULL;
     sess->rest_offset = 0;
+    sess->ufs = NULL;
+    strcpy(sess->ufs_cwd, "/");
     sess->server = server;
 
     /* Set default allocation from server config */
@@ -70,6 +73,8 @@ ftpd_session_free(ftpd_session_t *sess)
         closesocket(sess->pasv_sock);
     if (sess->ctrl_sock >= 0)
         closesocket(sess->ctrl_sock);
+
+    ftpd_ufs_free(sess);
 
     if (sess->acee)
         racf_logout(&sess->acee);

--- a/src/ftpd#ufs.c
+++ b/src/ftpd#ufs.c
@@ -1,0 +1,312 @@
+/*
+** FTPD UFS Operations — UFSD Client Integration
+**
+** Wrapper layer around libufs (UFSD client library).
+** Provides: session handle management, error mapping,
+** path resolution, and CWD/CDUP for UFS mode.
+**
+** Reference implementation: mvsmf/src/ussapi.c
+**
+** Codepage: UFS files are IBM-1047 (NOT CP037).
+** Use ftpd_xlat_a2e/e2a for UFS content translation.
+*/
+#include "ftpd.h"
+#include "ftpd#ses.h"
+#include "ftpd#ufs.h"
+
+#include "libufs.h"
+
+/* --------------------------------------------------------------------
+** UFSD RC -> FTP reply code mapping
+** ----------------------------------------------------------------- */
+int
+ftpd_ufs_rc_to_ftp(int rc)
+{
+    switch (rc) {
+    case UFSD_RC_OK:          return FTP_250;
+    case UFSD_RC_NOFILE:      return FTP_550;
+    case UFSD_RC_EXIST:       return FTP_550;
+    case UFSD_RC_NOTDIR:      return FTP_550;
+    case UFSD_RC_ISDIR:       return FTP_550;
+    case UFSD_RC_NOSPACE:     return FTP_452;
+    case UFSD_RC_NOINODES:    return FTP_452;
+    case UFSD_RC_IO:          return FTP_451;
+    case UFSD_RC_BADFD:       return FTP_451;
+    case UFSD_RC_NOTEMPTY:    return FTP_550;
+    case UFSD_RC_NAMETOOLONG: return FTP_553;
+    case UFSD_RC_ROFS:        return FTP_550;
+    case UFSD_RC_EACCES:      return FTP_550;
+    default:                  return FTP_451;
+    }
+}
+
+/* --------------------------------------------------------------------
+** UFSD RC -> human-readable message
+** ----------------------------------------------------------------- */
+const char *
+ftpd_ufs_rc_message(int rc)
+{
+    switch (rc) {
+    case UFSD_RC_OK:          return "Success";
+    case UFSD_RC_NOFILE:      return "File or directory not found";
+    case UFSD_RC_EXIST:       return "File or directory already exists";
+    case UFSD_RC_NOTDIR:      return "Not a directory";
+    case UFSD_RC_ISDIR:       return "Is a directory";
+    case UFSD_RC_NOSPACE:     return "No space left on device";
+    case UFSD_RC_NOINODES:    return "No inodes available";
+    case UFSD_RC_IO:          return "I/O error";
+    case UFSD_RC_BADFD:       return "Bad file descriptor";
+    case UFSD_RC_NOTEMPTY:    return "Directory not empty";
+    case UFSD_RC_NAMETOOLONG: return "Path name too long";
+    case UFSD_RC_ROFS:        return "Read-only file system";
+    case UFSD_RC_EACCES:      return "Permission denied";
+    default:                  return "UFS error";
+    }
+}
+
+/* --------------------------------------------------------------------
+** Send FTP error reply for a UFSD return code
+** ----------------------------------------------------------------- */
+void
+ftpd_ufs_error(ftpd_session_t *sess, int ufsd_rc)
+{
+    ftpd_session_reply(sess, ftpd_ufs_rc_to_ftp(ufsd_rc),
+                       "%s", ftpd_ufs_rc_message(ufsd_rc));
+}
+
+/* --------------------------------------------------------------------
+** Get per-session UFS handle (lazy init)
+**
+** Pattern follows mvsMF uss_get_ufs():
+**   1. ufsnew() — creates UFSD session via SVC 34
+**   2. ufs_setuser() — sets owner from ACEE for permission checks
+**
+** Returns NULL if UFSD is not running (sends 550 reply).
+** Caches handle in sess->ufs for subsequent calls.
+** ----------------------------------------------------------------- */
+UFS *
+ftpd_ufs_get(ftpd_session_t *sess)
+{
+    UFS *ufs;
+
+    // Return cached handle if available
+    if (sess->ufs)
+        return sess->ufs;
+
+    // Try to connect to UFSD
+    ufs = ufsnew();
+    if (!ufs) {
+        ftpd_session_reply(sess, FTP_550,
+                           "UFS service not available");
+        return NULL;
+    }
+
+    // Set session owner from ACEE (exactly like mvsMF uss_get_ufs)
+    if (sess->acee) {
+        ACEE *acee = sess->acee;
+        char userid[9];
+        char group[9];
+        unsigned char ulen = (unsigned char)acee->aceeuser[0];
+        unsigned char glen = (unsigned char)acee->aceegrp[0];
+        if (ulen > 8) ulen = 8;
+        if (glen > 8) glen = 8;
+        memset(userid, 0, sizeof(userid));
+        memset(group, 0, sizeof(group));
+        memcpy(userid, acee->aceeuser + 1, ulen);
+        memcpy(group, acee->aceegrp + 1, glen);
+        ufs_setuser(ufs, userid, group);
+    }
+
+    sess->ufs = ufs;
+    return ufs;
+}
+
+/* --------------------------------------------------------------------
+** Free per-session UFS handle
+** ----------------------------------------------------------------- */
+void
+ftpd_ufs_free(ftpd_session_t *sess)
+{
+    if (sess->ufs) {
+        ufsfree(&sess->ufs);
+        sess->ufs = NULL;
+    }
+}
+
+/* --------------------------------------------------------------------
+** Resolve path argument against session's UFS CWD.
+**
+** Rules:
+**   - Absolute path (/...) → use as-is
+**   - "." → current directory
+**   - ".." → parent directory
+**   - relative → append to cwd
+**   - Normalize: collapse "//", "/./" and "/../"
+**   - Prevent traversal above root "/"
+**
+** Returns 0 on success, -1 on error (path too long, invalid).
+** ----------------------------------------------------------------- */
+int
+ftpd_ufs_resolve(ftpd_session_t *sess, const char *arg,
+                 char *out, int outlen)
+{
+    char work[FTPD_MAX_PATH_LEN];
+    char *src;
+    char *dst;
+    char *seg;
+    char *next;
+    int len;
+
+    if (!arg || !arg[0]) {
+        // No argument — return current directory
+        strncpy(out, sess->ufs_cwd, outlen - 1);
+        out[outlen - 1] = '\0';
+        return 0;
+    }
+
+    // Build absolute path in work buffer
+    if (arg[0] == '/') {
+        // Absolute path
+        strncpy(work, arg, sizeof(work) - 1);
+        work[sizeof(work) - 1] = '\0';
+    } else {
+        // Relative to CWD
+        len = snprintf(work, sizeof(work), "%s/%s", sess->ufs_cwd, arg);
+        if (len >= (int)sizeof(work))
+            return -1;
+    }
+
+    // Normalize: resolve . and .. components
+    // Output always starts with /
+    dst = out;
+    *dst = '\0';
+
+    src = work;
+    if (*src == '/')
+        src++;
+
+    // Start with root
+    if (outlen < 2)
+        return -1;
+    dst[0] = '/';
+    dst[1] = '\0';
+    len = 1;
+
+    // Process each path segment
+    seg = src;
+    while (*seg) {
+        // Find end of segment
+        next = seg;
+        while (*next && *next != '/')
+            next++;
+
+        // Temporarily null-terminate segment
+        if (*next == '/') {
+            *next = '\0';
+            next++;
+        }
+
+        // Skip empty segments and "."
+        if (seg[0] == '\0' || strcmp(seg, ".") == 0) {
+            seg = next;
+            continue;
+        }
+
+        // Handle ".." — go up one level
+        if (strcmp(seg, "..") == 0) {
+            // Find last slash (not the trailing one)
+            char *last = out + len - 1;
+            if (len > 1) {
+                // Remove trailing slash if present
+                if (*last == '/')
+                    last--;
+                // Find previous slash
+                while (last > out && *last != '/')
+                    last--;
+                len = last - out + 1;
+                out[len] = '\0';
+            }
+            // At root — stay at root (prevent traversal)
+            seg = next;
+            continue;
+        }
+
+        // Append segment
+        if (len > 1) {
+            // Need slash separator (unless we're at root "/")
+            if (len + 1 >= outlen)
+                return -1;
+            out[len++] = '/';
+        }
+        if (len + (int)strlen(seg) >= outlen)
+            return -1;
+        strcpy(out + len, seg);
+        len += strlen(seg);
+
+        seg = next;
+    }
+
+    // Ensure at least "/"
+    if (len == 0) {
+        out[0] = '/';
+        out[1] = '\0';
+    }
+
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** CWD — change UFS working directory
+**
+** Validates the target path via ufs_chgdir().
+** On success, updates sess->ufs_cwd from the UFSD CWD.
+** ----------------------------------------------------------------- */
+int
+ftpd_ufs_cwd(ftpd_session_t *sess, const char *arg)
+{
+    UFS *ufs;
+    char path[FTPD_MAX_PATH_LEN];
+    int rc;
+    UFSCWD *cwd;
+
+    ufs = ftpd_ufs_get(sess);
+    if (!ufs)
+        return 0;
+
+    // Resolve the target path
+    if (ftpd_ufs_resolve(sess, arg, path, sizeof(path)) != 0) {
+        ftpd_session_reply(sess, FTP_550, "Invalid path");
+        return 0;
+    }
+
+    // Change directory via UFSD
+    rc = ufs_chgdir(ufs, path);
+    if (rc != UFSD_RC_OK) {
+        ftpd_ufs_error(sess, rc);
+        return 0;
+    }
+
+    // Update session CWD from UFSD
+    cwd = ufs_get_cwd(ufs);
+    if (cwd && cwd->path[0]) {
+        strncpy(sess->ufs_cwd, cwd->path, sizeof(sess->ufs_cwd) - 1);
+        sess->ufs_cwd[sizeof(sess->ufs_cwd) - 1] = '\0';
+    } else {
+        strncpy(sess->ufs_cwd, path, sizeof(sess->ufs_cwd) - 1);
+        sess->ufs_cwd[sizeof(sess->ufs_cwd) - 1] = '\0';
+    }
+
+    ftpd_session_reply(sess, FTP_250,
+                       "HFS directory %s is the current working directory",
+                       sess->ufs_cwd);
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** CDUP — move to parent UFS directory
+** ----------------------------------------------------------------- */
+int
+ftpd_ufs_cdup(ftpd_session_t *sess)
+{
+    return ftpd_ufs_cwd(sess, "..");
+}

--- a/test/test_ftpd.sh
+++ b/test/test_ftpd.sh
@@ -549,9 +549,60 @@ else
 fi
 
 # ============================================================
-# TEST 5: Cleanup (DELE)
+# TEST 5: UFS Mode Switching (Phase 3a)
 # ============================================================
-section "Test 5: Cleanup"
+section "Test 5: UFS Mode Switching"
+
+# CWD / — should switch to UFS mode (250) or fail gracefully (550)
+info "CWD / (UFS mode switch)"
+FTP_OUT="$TMPDIR/ftp_ufs_cwd.log"
+ftp_run "$(cat <<CMDS
+cd /
+pwd
+CMDS
+)" "$FTP_OUT"
+
+if grep -qi "250.*HFS directory\|257.*/" "$FTP_OUT"; then
+    pass "CWD / — UFS mode active"
+    UFS_AVAILABLE=1
+
+    # PWD should show UFS-style path
+    if grep -qi '257.*"/"' "$FTP_OUT"; then
+        pass "PWD in UFS mode shows /"
+    else
+        fail "PWD in UFS mode: expected /"
+        grep -i "257" "$FTP_OUT" | sed 's/^/    /'
+    fi
+
+    # CWD back to MVS mode
+    info "CWD '${HLQ}.' (back to MVS mode)"
+    FTP_OUT="$TMPDIR/ftp_ufs_back.log"
+    ftp_run "$(cat <<CMDS
+cd /
+cd '${HLQ}.'
+pwd
+CMDS
+)" "$FTP_OUT"
+    if grep -qi "257.*'${HLQ}\." "$FTP_OUT"; then
+        pass "CWD back to MVS mode"
+    else
+        fail "CWD back to MVS mode"
+        grep -i "257\|250\|550" "$FTP_OUT" | sed 's/^/    /'
+    fi
+elif grep -qi "550.*UFS service not available" "$FTP_OUT"; then
+    pass "CWD / — UFSD not running, graceful 550"
+    UFS_AVAILABLE=0
+    info "UFSD not running — skipping further UFS tests"
+else
+    fail "CWD / — unexpected response"
+    cat "$FTP_OUT" | sed 's/^/    /'
+    UFS_AVAILABLE=0
+fi
+
+# ============================================================
+# TEST 6: Cleanup (DELE)
+# ============================================================
+section "Test 6: Cleanup"
 
 info "DELE '$DSN_BIN'"
 FTP_OUT="$TMPDIR/ftp_cleanup.log"


### PR DESCRIPTION
## Summary

- Add `ftpd#ufs.c` / `ftpd#ufs.h` — UFSD client wrapper layer with lazy session init, error mapping, path resolution, CWD/CDUP handlers
- Extend session struct with `UFS*` handle (lazy init per session, freed on close)
- Update command dispatcher for hybrid MVS/UFS navigation: `CWD /` → UFS mode, `CWD 'DSN'` → MVS mode
- Add `mvslovers/ufsd` dependency to `project.toml` with NCALIB link integration
- Add UFS mode-switching tests to test suite

UFSD is a soft dependency — FTPD compiles, links, and runs without UFSD. If UFSD is not running, `CWD /` returns `550 UFS service not available`.

Fixes #26

## Test plan

- [ ] `make build` + `make link` — verify clean assembly and linkedit with UFSD NCALIB
- [ ] With UFSD running: `CWD /` → 250, `PWD` → `257 "/" is the HFS working directory`, `CWD 'IBMUSER.'` → back to MVS
- [ ] Without UFSD: `CWD /` → `550 UFS service not available`, session stays in MVS mode
- [ ] Existing MVS + JES tests unaffected
- [ ] `test/test_ftpd.sh` — run full suite, verify UFS section passes or gracefully skips