### PR TITLE
Phase 3c: Hybrid MVS/UFS/JES navigation

### DIFF
--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -27,6 +27,7 @@ struct ftpd_session {
     int             state;          /* session state                 */
     int             filetype;       /* FT_SEQ or FT_JES             */
     int             fsmode;         /* FS_MVS or FS_UFS             */
+    int             prev_fsmode;    /* saved fsmode during JES mode  */
     char            type;           /* 'A','E','I' transfer type     */
     char            stru;           /* 'F','R' structure             */
 

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -330,8 +330,14 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
     if (strcmp(cmd, "CWD") == 0 || strcmp(cmd, "XCWD") == 0) {
         // Mode switching: CWD /... → UFS, CWD 'DSN' → MVS
         if (arg[0] == '/') {
-            // Switch to UFS mode
+            // Try UFS — only switch mode if ftpd_ufs_get() succeeds
+            // (prevents getting stuck in UFS mode when UFSD is down)
+            int prev = sess->fsmode;
             sess->fsmode = FS_UFS;
+            if (!ftpd_ufs_get(sess)) {
+                sess->fsmode = prev;  // UFSD not available, stay
+                return 0;            // 550 already sent
+            }
             return ftpd_ufs_cwd(sess, arg);
         }
         if (sess->fsmode == FS_UFS) {

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -31,6 +31,7 @@ ftpd_session_new(ftpd_server_t *server, int sock)
     sess->state = SESS_GREETING;
     sess->filetype = FT_SEQ;
     sess->fsmode = FS_MVS;
+    sess->prev_fsmode = FS_MVS;
     sess->type = XFER_TYPE_A;
     sess->stru = XFER_STRU_F;
     sess->authenticated = 0;

--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -168,9 +168,13 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
         for (i = 0; val[i]; i++)
             val[i] = (char)toupper((unsigned char)val[i]);
         if (strcmp(val, "JES") == 0) {
+            // Save current fsmode so FILETYPE=SEQ can restore it
+            sess->prev_fsmode = sess->fsmode;
             sess->filetype = FT_JES;
         } else {
             sess->filetype = FT_SEQ;
+            // Restore fsmode saved when entering JES mode
+            sess->fsmode = sess->prev_fsmode;
         }
         ftpd_session_reply(sess, FTP_200, "SITE command was accepted");
         return 0;

--- a/test/test_ftpd.sh
+++ b/test/test_ftpd.sh
@@ -850,6 +850,74 @@ fi
 fi  # UFS_AVAILABLE
 
 # ============================================================
+# TEST 5c: Hybrid Navigation (Phase 3c) — only if UFSD running
+# ============================================================
+if [ "${UFS_AVAILABLE:-0}" = "1" ]; then
+section "Test 5c: Hybrid MVS/UFS/JES Navigation"
+
+# Full hybrid cycle in a single session:
+# MVS → UFS → MVS → JES → back to MVS
+info "Hybrid: MVS → UFS → MVS → JES → MVS"
+FTP_OUT="$TMPDIR/ftp_hybrid.log"
+ftp_run "$(cat <<CMDS
+pwd
+cd /
+pwd
+cd '${HLQ}.'
+pwd
+site filetype=jes
+site filetype=seq
+pwd
+CMDS
+)" "$FTP_OUT"
+
+# Check MVS mode at start
+if grep -qi "257.*${HLQ}\.\|working directory.*${HLQ}" "$FTP_OUT"; then
+    pass "Hybrid: starts in MVS mode"
+else
+    fail "Hybrid: expected MVS mode at start"
+    cat "$FTP_OUT" | sed 's/^/    /'
+fi
+
+# Check UFS mode after CWD /
+if grep -qi "250.*HFS directory.*/" "$FTP_OUT"; then
+    pass "Hybrid: CWD / switches to UFS"
+else
+    fail "Hybrid: CWD / did not switch to UFS"
+fi
+
+# Check MVS mode after CWD 'HLQ.'
+if grep -qi "250.*${HLQ}\.\|working directory.*${HLQ}" "$FTP_OUT"; then
+    pass "Hybrid: CWD 'HLQ.' switches back to MVS"
+else
+    fail "Hybrid: CWD 'HLQ.' did not switch to MVS"
+fi
+
+# SITE FILETYPE=JES from UFS mode, then back
+info "Hybrid: JES from UFS mode preserves fsmode"
+FTP_OUT="$TMPDIR/ftp_hybrid_jes.log"
+ftp_run "$(cat <<CMDS
+cd /
+pwd
+site filetype=jes
+site filetype=seq
+pwd
+CMDS
+)" "$FTP_OUT"
+
+# After JES→SEQ, PWD should show UFS (restored from before JES)
+if grep -qi 'HFS.*working directory\|"/"' "$FTP_OUT"; then
+    pass "Hybrid: FILETYPE=SEQ restores UFS mode"
+else
+    # Check if at least the commands succeeded
+    info "Hybrid JES→SEQ output:"
+    grep -i "250\|257\|200\|215" "$FTP_OUT" | sed 's/^/    /'
+    fail "Hybrid: FILETYPE=SEQ did not restore UFS mode"
+fi
+
+fi  # UFS_AVAILABLE (hybrid)
+
+# ============================================================
 # TEST 6: Cleanup (DELE)
 # ============================================================
 section "Test 6: Cleanup"


### PR DESCRIPTION
## Summary

- Fix CWD / edge case: verify UFSD availability before switching fsmode (prevents stuck-in-UFS-mode when UFSD is down)
- Add `prev_fsmode` to session: `SITE FILETYPE=JES` saves current fsmode, `SITE FILETYPE=SEQ` restores it
- Add hybrid navigation end-to-end tests (MVS → UFS → MVS → JES → back)

Note: MVS build not verified (mvsMF was unreachable during development). Changes are minimal — 1 struct field, ~10 lines of logic.

Fixes #30

## Test plan

- [ ] `make build && make link` — verify clean build
- [ ] Hybrid cycle: login (MVS) → CWD / (UFS) → CWD 'HLQ.' (MVS) → SITE FILETYPE=JES → SITE FILETYPE=SEQ → PWD shows MVS
- [ ] JES from UFS: CWD / → SITE FILETYPE=JES → SITE FILETYPE=SEQ → PWD shows UFS (restored)
- [ ] CWD / with UFSD down → 550, stays in MVS mode (not stuck)
- [ ] `test/test_ftpd.sh` — full suite