### PR TITLE
Implement EPSV/EPRT support (RFC 2428)

### DIFF
--- a/include/ftpd#dat.h
+++ b/include/ftpd#dat.h
@@ -18,6 +18,12 @@ int ftpd_data_port(ftpd_session_t *sess, const char *arg)
 int ftpd_data_pasv(ftpd_session_t *sess)                    asm("FTPDTPSV");
 
 /*
+** Open passive listener, send 229 reply (RFC 2428).
+** Returns 0 on success, -1 on error.
+*/
+int ftpd_data_epsv(ftpd_session_t *sess)                    asm("FTPDTEPV");
+
+/*
 ** Establish data connection (accept for PASV, connect for PORT).
 ** Returns 0 on success, -1 on error.
 */

--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -57,6 +57,9 @@ struct ftpd_session {
     /* SITE allocation defaults */
     ftpd_alloc_t    alloc;
 
+    /* EPSV ALL lock (RFC 2428) */
+    int             epsv_all;       /* 1 = EPSV ALL active           */
+
     /* Transfer modifiers (SITE toggles) */
     int             trailing;       /* SITE TRAILING (0=keep blanks) */
     int             truncate;       /* SITE TRUNCATE                 */

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -76,6 +76,7 @@ typedef unsigned char   UCHAR;
 #define FTP_221             221     /* closing control connection    */
 #define FTP_226             226     /* closing data, xfer complete   */
 #define FTP_227             227     /* entering passive mode         */
+#define FTP_229             229     /* entering extended passive mode */
 #define FTP_230             230     /* user logged in                */
 #define FTP_250             250     /* file action okay              */
 #define FTP_257             257     /* pathname created              */
@@ -95,6 +96,7 @@ typedef unsigned char   UCHAR;
 #define FTP_530             530     /* not logged in                 */
 #define FTP_550             550     /* file unavailable              */
 #define FTP_552             552     /* exceeded storage allocation   */
+#define FTP_522             522     /* network proto not supported   */
 #define FTP_553             553     /* file name not allowed         */
 
 /* --- Limits --- */

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -72,6 +72,7 @@ cmd_feat(ftpd_session_t *sess)
     int len, i;
     len = snprintf(buf, sizeof(buf),
         "211-Features supported\r\n"
+        " EPSV\r\n"
         " SIZE\r\n"
         " MDTM\r\n"
         " SITE FILETYPE\r\n"
@@ -307,6 +308,11 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         return 0;
     }
     if (strcmp(cmd, "PORT") == 0) {
+        if (sess->epsv_all) {
+            ftpd_session_reply(sess, FTP_501,
+                "PORT not allowed after EPSV ALL");
+            return 0;
+        }
         if (ftpd_data_port(sess, arg) == 0) {
             ftpd_session_reply(sess, FTP_200, "PORT command successful");
         } else {
@@ -316,10 +322,35 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         return 0;
     }
     if (strcmp(cmd, "PASV") == 0) {
+        if (sess->epsv_all) {
+            ftpd_session_reply(sess, FTP_501,
+                "PASV not allowed after EPSV ALL");
+            return 0;
+        }
         if (ftpd_data_pasv(sess) != 0) {
             ftpd_session_reply(sess, FTP_425,
                                "Cannot open passive connection");
         }
+        return 0;
+    }
+    if (strcmp(cmd, "EPSV") == 0) {
+        /* EPSV ALL — lock session to EPSV-only mode */
+        if (arg[0] && (strcmp(arg, "ALL") == 0 ||
+                       strcmp(arg, "all") == 0)) {
+            sess->epsv_all = 1;
+            ftpd_session_reply(sess, FTP_200,
+                "EPSV ALL command successful.");
+            return 0;
+        }
+        if (ftpd_data_epsv(sess) != 0) {
+            ftpd_session_reply(sess, FTP_425,
+                               "Cannot open passive connection");
+        }
+        return 0;
+    }
+    if (strcmp(cmd, "EPRT") == 0) {
+        ftpd_session_reply(sess, FTP_522,
+            "Network protocol not supported, use (1)");
         return 0;
     }
     if (strcmp(cmd, "ABOR") == 0) {

--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -118,6 +118,66 @@ ftpd_data_pasv(ftpd_session_t *sess)
 }
 
 /* --------------------------------------------------------------------
+** Open passive listener for EPSV (RFC 2428).
+** Same logic as PASV but sends 229 response with (|||port|) format.
+** Returns 0 on success, -1 on error.
+** ----------------------------------------------------------------- */
+int
+ftpd_data_epsv(ftpd_session_t *sess)
+{
+    struct sockaddr_in addr;
+    int sock;
+    int port;
+
+    /* Close any existing data connection */
+    ftpd_data_close(sess);
+
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        ftpd_log(LOG_ERROR, "%s: socket() failed, errno=%d", __func__, errno);
+        return -1;
+    }
+
+    /* Try ports in the configured range */
+    for (port = sess->server->config.pasv_lo;
+         port <= sess->server->config.pasv_hi;
+         port++) {
+
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = 0;  /* bind to any address */
+        addr.sin_port = htons(port);
+
+        if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+            break;
+    }
+
+    if (port > sess->server->config.pasv_hi) {
+        ftpd_log(LOG_ERROR, "%s: no port available in range %d-%d",
+                 __func__, sess->server->config.pasv_lo,
+                 sess->server->config.pasv_hi);
+        closesocket(sock);
+        return -1;
+    }
+
+    if (listen(sock, 1) < 0) {
+        ftpd_log(LOG_ERROR, "%s: listen() failed, errno=%d", __func__, errno);
+        closesocket(sock);
+        return -1;
+    }
+
+    sess->pasv_sock = sock;
+    sess->data_mode = DATA_PASV;
+
+    ftpd_session_reply(sess, FTP_229,
+                       "Entering Extended Passive Mode (|||%d|)", port);
+
+    ftpd_trace("EPSV: listening on port %d", port);
+
+    return 0;
+}
+
+/* --------------------------------------------------------------------
 ** Establish data connection.
 ** For PORT: connect to client.
 ** For PASV: accept from passive listener.


### PR DESCRIPTION
## Summary

- Add EPSV command: opens passive listener, responds with `229 Entering Extended Passive Mode (|||port|)` — client reuses control connection IP
- Add EPSV ALL: locks session to EPSV-only mode, rejects PORT/PASV with 501
- Add EPRT command: responds with `522 Network protocol not supported, use (1)` (IPv4 only, no active extended needed)
- Advertise EPSV in FEAT response
- Session struct gains `epsv_all` flag for EPSV ALL enforcement

## Context

Modern FTP clients (Reflection Desktop, etc.) send EPSV before PASV. Some do NOT fall back gracefully and show an error dialog when EPSV returns `500 unknown command`.

## Test plan

- [ ] Connect with Reflection Desktop — no more EPSV error dialog
- [ ] `EPSV` → `229 Entering Extended Passive Mode (|||port|)`
- [ ] `EPSV ALL` → `200`, then `PORT` → `501`, `PASV` → `501`
- [ ] `EPRT` → `522`
- [ ] `FEAT` lists `EPSV`
- [ ] Existing PASV/PORT transfers still work

Fixes #32