### PR TITLE
Fix AUTH TLS/SSL returning 530 instead of 502

### DIFF
--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -263,6 +263,10 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         if (strcmp(cmd, "HELP") == 0) return cmd_help(sess);
         if (strcmp(cmd, "NOOP") == 0) return cmd_noop(sess);
         if (strcmp(cmd, "STAT") == 0) return cmd_stat(sess);
+        if (strcmp(cmd, "AUTH") == 0) {
+            ftpd_session_reply(sess, FTP_502, "Command not implemented");
+            return 0;
+        }
 
         ftpd_session_reply(sess, FTP_530, "Not logged in.");
         return 0;


### PR DESCRIPTION
## Summary

- Add `AUTH` to pre-auth command allowlist in `ftpd#cmd.c`
- Return `502 Command not implemented` instead of `530 Not logged in`

## Context

FileZilla sends `AUTH TLS` and `AUTH SSL` before login. Since `AUTH` wasn't in the pre-auth allowlist, it fell through to the generic 530 response.

## Test plan

- [ ] Connect with FileZilla — `AUTH TLS` → `502`, then continues with `USER`/`PASS` normally
- [ ] Pre-auth commands (SYST, FEAT, HELP, etc.) still work

Fixes #34