### PR TITLE
Fix AUTH TLS/SSL and OPTS UTF8 handling for FileZilla

### DIFF
--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -263,6 +263,11 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         if (strcmp(cmd, "HELP") == 0) return cmd_help(sess);
         if (strcmp(cmd, "NOOP") == 0) return cmd_noop(sess);
         if (strcmp(cmd, "STAT") == 0) return cmd_stat(sess);
+        if (strcmp(cmd, "AUTH") == 0) {
+            ftpd_session_reply(sess, FTP_504,
+                "Security mechanism not implemented.");
+            return 0;
+        }
 
         ftpd_session_reply(sess, FTP_530, "Not logged in.");
         return 0;
@@ -470,6 +475,16 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
     }
     if (strcmp(cmd, "SITE") == 0) {
         return ftpd_site_dispatch(sess, arg);
+    }
+    if (strcmp(cmd, "OPTS") == 0) {
+        ftpd_session_reply(sess, FTP_202,
+            "UTF8 mode is always enabled.");
+        return 0;
+    }
+    if (strcmp(cmd, "AUTH") == 0) {
+        ftpd_session_reply(sess, FTP_504,
+            "Security mechanism not implemented.");
+        return 0;
     }
 
     /* Unknown command */


### PR DESCRIPTION
## Summary

- `AUTH` added to pre-auth allowlist → `504 Security mechanism not implemented.`
- `AUTH` also handled post-auth (in case client retries after login)
- `OPTS` (e.g. `OPTS UTF8 ON`) → `202 UTF8 mode is always enabled.`

## Context

FileZilla sends `AUTH TLS`, `AUTH SSL` before login and `OPTS UTF8 ON` after login. Both returned incorrect error codes (530 and 500 respectively). Closed stale PR #35.

## Test plan

- [ ] FileZilla: `AUTH TLS` → `504` (before login)
- [ ] FileZilla: `AUTH SSL` → `504` (before login)
- [ ] FileZilla: `OPTS UTF8 ON` → `202` (after login)
- [ ] Normal login flow unaffected

Fixes #34