### PR TITLE
fix: PWD in PDS mode matches z/OS format

### DIFF
--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -302,9 +302,15 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
     }
     if (strcmp(cmd, "PWD") == 0 || strcmp(cmd, "XPWD") == 0) {
         if (sess->fsmode == FS_MVS) {
-            ftpd_session_reply(sess, FTP_257,
-                               "\"'%s'\" is working directory.",
-                               sess->mvs_cwd);
+            if (sess->in_pds) {
+                ftpd_session_reply(sess, FTP_257,
+                    "\"'%s'\" partitioned data set is working directory.",
+                    sess->pds_name);
+            } else {
+                ftpd_session_reply(sess, FTP_257,
+                    "\"'%s'\" is working directory.",
+                    sess->mvs_cwd);
+            }
         } else {
             ftpd_session_reply(sess, FTP_257,
                                "\"%s\" is the HFS working directory.",


### PR DESCRIPTION
## Summary
- In PDS mode, PWD now uses `sess->pds_name` (no trailing dot) instead of `sess->mvs_cwd` (which always has a trailing dot)
- Response text includes "partitioned data set" matching z/OS 3.1 behavior
- Fixes FileZilla building broken CWD paths after navigating into a PDS

Closes #41

## Test plan
- [ ] Connect with FileZilla, double-click a PDS → members listed, clicking a member works
- [ ] `tnftp`: `cd 'SYS1.MACLIB'` then `pwd` → `257 "'SYS1.MACLIB'" partitioned data set is working directory.`
- [ ] Prefix mode PWD unchanged: trailing dot, no "partitioned data set" text