### PR TITLE
fix: drop POSIX sockaddr cast on bind/accept/connect

### DIFF
--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -72,7 +72,7 @@ ftpd_data_pasv(ftpd_session_t *sess)
         addr.sin_addr.s_addr = 0;  /* bind to any address */
         addr.sin_port = htons(port);
 
-        if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+        if (bind(sock, &addr, sizeof(addr)) == 0)
             break;
     }
 
@@ -148,7 +148,7 @@ ftpd_data_epsv(ftpd_session_t *sess)
         addr.sin_addr.s_addr = 0;  /* bind to any address */
         addr.sin_port = htons(port);
 
-        if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+        if (bind(sock, &addr, sizeof(addr)) == 0)
             break;
     }
 
@@ -210,7 +210,7 @@ ftpd_data_open(ftpd_session_t *sess)
         }
 
         len = sizeof(addr);
-        sock = accept(sess->pasv_sock, (struct sockaddr *)&addr, &len);
+        sock = accept(sess->pasv_sock, &addr, &len);
         closesocket(sess->pasv_sock);
         sess->pasv_sock = -1;
 
@@ -239,7 +239,7 @@ ftpd_data_open(ftpd_session_t *sess)
         addr.sin_addr.s_addr = htonl(sess->data_addr);
         addr.sin_port = htons(sess->data_port);
 
-        if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        if (connect(sock, &addr, sizeof(addr)) < 0) {
             ftpd_log(LOG_ERROR, "%s: connect() failed, errno=%d", __func__,
                      errno);
             closesocket(sock);

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -279,15 +279,14 @@ socket_thread(void *arg1, void *arg2)
         }
     }
 
-    if (bind(sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+    if (bind(sock, &saddr, sizeof(saddr)) < 0) {
         int err = errno;
         ftpd_log_wto("FTPD051E bind() failed on port %d, errno=%d",
                      server->config.port, err);
         if (err == EADDRINUSE) {
             ftpd_log_wto("FTPD051I EADDRINUSE, retrying in 10s");
             __asm__("STIMER WAIT,BINTVL==F'1000'");
-            if (bind(sock, (struct sockaddr *)&saddr,
-                     sizeof(saddr)) < 0) {
+            if (bind(sock, &saddr, sizeof(saddr)) < 0) {
                 ftpd_log_wto("FTPD051E bind() retry failed, errno=%d",
                              errno);
                 closesocket(sock);
@@ -336,7 +335,7 @@ socket_thread(void *arg1, void *arg2)
 
         /* Try accept — non-blocking, returns <0 if no connection */
         len = sizeof(caddr);
-        rc = accept(sock, (struct sockaddr *)&caddr, &len);
+        rc = accept(sock, &caddr, &len);
         if (rc < 0)
             continue;   /* EWOULDBLOCK — no pending connection */
 


### PR DESCRIPTION
## Summary

cc370 reported `passing arg 2 ... from incompatible pointer type` for
`bind()`, `accept()` and `connect()` at 7 call sites in `src/ftpd.c` and
`src/ftpd#dat.c`.

crent370/cc370 declare these functions with a `struct sockaddr_in *` second
argument (not the POSIX `struct sockaddr *`). The call sites cast the address to
`(struct sockaddr *)`, which is an incompatible pointer type under those
prototypes. This passes the `struct sockaddr_in` address directly, matching the
crent370 prototypes and the existing ecosystem style (e.g. httpd).

`getsockname()` is declared with `struct sockaddr *`, so its cast is correct and
left unchanged.

## Changes

- `src/ftpd#dat.c`: bind (PASV/EPSV), accept (data open), connect (active)
- `src/ftpd.c`: bind (listener + EADDRINUSE retry), accept (accept loop)

## Verification

Host build (`make`) completes with **zero warnings** (previously 7); link of
`FTPD` unchanged.

Closes #57