### PR TITLE
Add ESTAE recovery around per-command processing (try()/tryrc())

### DIFF
--- a/doc/FTPD_RAKF_SETUP.md
+++ b/doc/FTPD_RAKF_SETUP.md
@@ -165,6 +165,29 @@ under the default identity with a warning:
 FTPD004W RACINIT ENVIR=CREATE failed RC=nn
 ```
 
+### 5.1 SECURITY INVARIANT — `FTPD/USER` must be least-privilege
+
+> **This is a security invariant, not a recommendation.**
+>
+> `FTPD/USER` **must not** be granted broad dataset authority (no
+> `OPERATIONS`-equivalent access, no wide `ID(FTPD) ACCESS(ALTER)`
+> profiles). Its only required authority is what the STC itself needs
+> to run — not access to user data. Per-user data access is authorized
+> against the **logged-in user's** identity, never `FTPD/USER`.
+>
+> **Why it is an invariant:** the per-command ABEND recovery handler
+> resets the address-space-wide security environment (ASXBSENV) to the
+> `FTPD/USER` ACEE after an unexpected ABEND. Because sessions run as
+> concurrent subtasks sharing that one field, a concurrent session can
+> be transiently pulled onto `FTPD/USER` during recovery. This is
+> deliberately **fail-closed** *only while `FTPD/USER` is minimally
+> privileged*: a session pulled onto it can lose authority, never gain
+> it. If `FTPD/USER` is given broad dataset authority, that same
+> transient switch becomes **fail-open** — a concurrent session's
+> dataset OPEN could momentarily authorize with elevated access.
+>
+> Keep `FTPD/USER` scoped to the STC's own needs.
+
 ---
 
 ## 6. Reuse for Other STCs

--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -7,6 +7,7 @@
 
 /* Forward declaration — full definition in libufs.h */
 struct libufs_ufs;
+struct libufs_file;
 
 /* --- Session structure --- */
 struct ftpd_session {
@@ -72,6 +73,19 @@ struct ftpd_session {
     /* Command buffer */
     char            cmd[FTPD_MAX_CMD_LEN]; /* current command line   */
     int             cmdlen;         /* command length                 */
+    int             dispatch_rc;    /* rc stashed by the try()-wrapped
+                                    ** command dispatch (try() itself
+                                    ** returns the ABEND code, not the
+                                    ** handler's rc)                   */
+
+    /* In-flight resources released by ABEND recovery */
+    FILE            *cur_file;      /* open dataset FILE* during a
+                                    ** RETR/STOR/APPE transfer; NULL
+                                    ** otherwise. fclose() releases the
+                                    ** DCB + fopen's dynalloc DD.       */
+    struct libufs_file *cur_ufs_file; /* open UFSD file during a UFS
+                                    ** RETR/STOR transfer; NULL else.
+                                    ** ufs_fclose() releases it.        */
 
     /* Idle tracking (heap — immune to SVC stack corruption) */
     time_t          idle_start;     /* getline idle timer start       */

--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -86,6 +86,12 @@ struct ftpd_session {
     struct libufs_file *cur_ufs_file; /* open UFSD file during a UFS
                                     ** RETR/STOR transfer; NULL else.
                                     ** ufs_fclose() releases it.        */
+#ifdef FTPD_DEBUG_ABEND
+    int             debug_abend_xfer; /* armed by SITE ABEND=XFER: the
+                                    ** next MVS RETR ABENDs mid-transfer
+                                    ** (cur_file set, data conn open) —
+                                    ** debug builds only.               */
+#endif
 
     /* Idle tracking (heap — immune to SVC stack corruption) */
     time_t          idle_start;     /* getline idle timer start       */

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -22,6 +22,7 @@
 #include "clibcib.h"                /* console information blocks   */
 #include "socket.h"                 /* sockets via DYN75            */
 #include "racf.h"                   /* security environment         */
+#include "clibtry.h"                /* try(), tryrc() ESTAE recovery */
 
 #include "ftpd#cfg.h"               /* configuration                */
 #include "ftpd#log.h"               /* logging & trace              */
@@ -107,6 +108,12 @@ typedef unsigned char   UCHAR;
 #define FTPD_MAX_USER_LEN   8       /* max userid length             */
 #define FTPD_DATA_BUF_SIZE  4096    /* data transfer buffer size     */
 
+/* --- ABEND recovery --- */
+#define FTPD_MAX_RECOVER    3       /* consecutive per-command ABEND
+                                    ** recoveries before the session is
+                                    ** closed (guards against a wedged
+                                    ** session recovering forever)     */
+
 /* --- Allocation defaults for new datasets --- */
 typedef struct ftpd_alloc {
     char            recfm[4];       /* RECFM for new datasets        */
@@ -135,6 +142,9 @@ struct ftpd_server {
 #define FTPD_QUIESCE        0x02    /* shutdown in progress          */
 
     ftpd_config_t   config;         /* server configuration          */
+    ACEE            *stc_acee;      /* STC identity ACEE, captured at
+                                    ** init; recovery resets ASXBSENV
+                                    ** to this after an ABEND          */
     int             listen_sock;    /* listening socket fd            */
     CTHDMGR         *mgr;          /* thread manager                */
     CTHDTASK        *sock_task;    /* socket listener thread         */
@@ -143,6 +153,9 @@ struct ftpd_server {
     long            total_sessions; /* total sessions since start     */
     long            total_bytes_in; /* total bytes received           */
     long            total_bytes_out;/* total bytes sent               */
+    unsigned        total_recover;  /* ABEND recoveries since start
+                                    ** (STC-lifetime; observability for
+                                    ** documented residual leaks)      */
 };
 
 extern ftpd_server_t *ftpd_server;

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -1191,6 +1191,19 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
 
     total = 0;
 
+#ifdef FTPD_DEBUG_ABEND
+    /* SITE ABEND=XFER injection (#63): ABEND here with cur_file set and the
+    ** data connection open, to exercise recovery's fclose(cur_file) +
+    ** clear-before-close idempotency.  One-shot: disarm before firing. */
+    if (sess->debug_abend_xfer) {
+        volatile int *trap = (volatile int *)0;
+        sess->debug_abend_xfer = 0;
+        ftpd_log_wto("FTPD072W DEBUG ABEND=XFER firing mid-RETR socket=%d",
+                     sess->ctrl_sock);
+        *trap = 0;                     /* force S0C4 */
+    }
+#endif
+
     ftpd_log(LOG_INFO, "RETR: dsn=%s type=%c lrecl=%d blksize=%d recfm=0x%02X",
              dsn, sess->type == XFER_TYPE_I ? 'I' :
                   sess->type == XFER_TYPE_A ? 'A' : 'E',

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -1162,6 +1162,10 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Track the open handle so ABEND recovery can release it (DCB +
+    ** fopen's dynalloc DD) if the transfer below ABENDs. */
+    sess->cur_file = fp;
+
     /* Read LRECL/RECFM from file handle — crent370 populates from DCB.
     ** For RECFM=U, lrecl is 0; use blksize instead (mvsmf pattern). */
     is_fixed = (fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_F;
@@ -1178,6 +1182,7 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
         recfm_label(fp->recfm), lrecl);
 
     if (ftpd_data_open(sess) != 0) {
+        sess->cur_file = NULL;
         fclose(fp);
         ftpd_session_reply(sess, FTP_425,
                            "Cannot open data connection");
@@ -1246,6 +1251,7 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
     }
 
     ftpd_log(LOG_INFO, "RETR: closing %s", fname);
+    sess->cur_file = NULL;
     fclose(fp);
     ftpd_data_close(sess);
 
@@ -1583,7 +1589,16 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
         /* Allocate under the logged-in user's security environment, not
         ** the STC identity — the subsequent fopen()/OPEN runs under the
         ** same ACEE. Running SVC 99 under FTPD would authorize against
-        ** the STC, then OPEN under the user ACEE would ABEND S130. */
+        ** the STC, then OPEN under the user ACEE would ABEND S130.
+        **
+        ** NOTE (ABEND-recovery residual): this __dsalcf/__dsfree pair
+        ** completes before cur_file is set, so an ABEND in this narrow
+        ** window is NOT caught by recovery's fclose(cur_file).  It would
+        ** leak the DD and, because DISP=(NEW,CATLG,DELETE) catalogs on
+        ** normal disposition, leave an empty catalogued dataset behind.
+        ** The window is a few instructions (two SVC 99 calls) and is not
+        ** instrumented; total_recover in the operator log makes any such
+        ** accumulation observable. */
         {
             ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
             rc = __dsalcf(ddname, "%s", opts);
@@ -1622,10 +1637,15 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Track the open handle so ABEND recovery can release it (DCB +
+    ** fopen's dynalloc DD) if the transfer below ABENDs. */
+    sess->cur_file = fp;
+
     ftpd_session_reply(sess, FTP_125, "Storing data set %s",
                        member[0] ? arg : dsn);
 
     if (ftpd_data_open(sess) != 0) {
+        sess->cur_file = NULL;
         fclose(fp);
         ftpd_session_reply(sess, FTP_425,
                            "Cannot open data connection");
@@ -1656,6 +1676,7 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
         int recnum = 0;
 
         if (eff_lrecl == 0) {
+            sess->cur_file = NULL;
             fclose(fp);
             ftpd_data_close(sess);
             ftpd_session_reply(sess, FTP_550,
@@ -1665,6 +1686,7 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
 
         record_buffer = calloc(1, eff_lrecl);
         if (!record_buffer) {
+            sess->cur_file = NULL;
             fclose(fp);
             ftpd_data_close(sess);
             ftpd_session_reply(sess, FTP_550,
@@ -1804,6 +1826,7 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
     }
 
     ftpd_log(LOG_INFO, "STOR: closing %s", fname);
+    sess->cur_file = NULL;
     fclose(fp);
     ftpd_data_close(sess);
 

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -273,7 +273,15 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
     ** possibly at an ACEE that is about to be freed.  Restoring the STC
     ** identity re-establishes the AS's normal resting state and is fail-
     ** closed: FTPD/USER is least-privilege, so any concurrent session
-    ** transiently pulled onto it can only lose authority, never gain it. */
+    ** transiently pulled onto it can only lose authority, never gain it.
+    **
+    ** ORDER IS LOAD-BEARING: this set_acee(STC) MUST precede the
+    ** unlock(asxb) in step 2.  If the lock were released first, a worker
+    ** waiting in racf_auth() would acquire it and capture THIS session's
+    ** user ACEE (still in ASXBSENV) as its own oldacee, then restore that
+    ** ACEE on exit — leaving ASXBSENV dangling once this session ends and
+    ** racf_logout() frees it.  That is precisely the dangling-ACEE hazard
+    ** this reset exists to remove.  Do not reorder. */
     racf_set_acee(sess->server->stc_acee);
 
     /* 2. Release the ASXB ENQ if this task ABENDed inside racf_auth()'s

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -7,7 +7,10 @@
 #include "ftpd.h"
 #include "ftpd#ses.h"
 #include "ftpd#cmd.h"
+#include "ftpd#dat.h"
 #include "ftpd#ufs.h"
+#include "libufs.h"                 /* UFSFILE, ufs_fclose()          */
+#include "cliblock.h"               /* unlock() — release orphaned ENQ */
 
 /* --------------------------------------------------------------------
 ** Allocate and initialize a new session
@@ -225,6 +228,113 @@ ftpd_session_getline(ftpd_session_t *sess)
 }
 
 /* --------------------------------------------------------------------
+** try()-wrapped command dispatch.
+**
+** try() returns the ABEND code (0 on clean completion) and discards the
+** wrapped function's own return value, so ftpd_cmd_dispatch()'s rc — which
+** signals the command loop to exit (QUIT, auth failure, fatal I/O) — is
+** stashed in the session and read by the caller after try() returns.
+** ----------------------------------------------------------------- */
+static int
+ftpd_run_command(ftpd_session_t *sess, const char *cmd, const char *arg)
+{
+    sess->dispatch_rc = ftpd_cmd_dispatch(sess, cmd, arg);
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** Per-command ABEND recovery.
+**
+** Runs after try() catches an ABEND in ftpd_run_command().  crent370's
+** try() is SDWA-retry that unwinds the stack back to the try() frame and
+** resumes in normal task mode, so this handler runs on a valid stack and
+** may use ordinary services (racf_set_acee, fclose, send, WTO).  The
+** session struct is heap-allocated and survives; only stack frames below
+** try() are gone.
+**
+** This function is itself run under try() by the caller, so a re-ABEND in
+** a cleanup step is contained.  Ordering is therefore deliberate: restore
+** identity and release the ASXB ENQ first (so they hold even on a re-
+** ABEND); WTO + tell the client next; and only then perform the one step
+** that can plausibly re-ABEND (fclose on a possibly-corrupt DCB), so a
+** cleanup failure can never leave the client hanging.
+**
+** 'verb' is the parsed FTP command word only (no arguments) — never the
+** raw command line, which for PASS would contain the password.
+** ----------------------------------------------------------------- */
+static int
+ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
+{
+    FILE *fp;
+
+    /* 1. Reset the address-space-wide ASXBSENV to the STC identity.  If
+    ** the ABEND struck while switched to the user's ACEE (inside a
+    ** RETR/STOR/LIST OPEN), the shared field still points at the user —
+    ** possibly at an ACEE that is about to be freed.  Restoring the STC
+    ** identity re-establishes the AS's normal resting state and is fail-
+    ** closed: FTPD/USER is least-privilege, so any concurrent session
+    ** transiently pulled onto it can only lose authority, never gain it. */
+    racf_set_acee(sess->server->stc_acee);
+
+    /* 2. Release the ASXB ENQ if this task ABENDed inside racf_auth()'s
+    ** lock(asxb)/unlock(asxb) critical section.  MVS DEQs a task's ENQs
+    ** at task termination, but recovery keeps the task alive, so an
+    ** orphaned AS-wide ENQ would stall every session's racf_auth() until
+    ** this worker's next command.  unlock() is safe when not held. */
+    {
+        unsigned *psa  = (unsigned *)0;
+        unsigned *ascb = (unsigned *)psa[0x224/4];  /* PSAAOLD  -> ASCB */
+        unsigned *asxb = (unsigned *)ascb[0x6C/4];  /* ASCBASXB -> ASXB */
+        unlock(asxb, 0);
+    }
+
+    /* 3. Count + WTO now, before the risky cleanup, so the diagnostic
+    ** survives even a cleanup re-ABEND.  total_recover accumulates over
+    ** the STC lifetime (per-session growth is bounded by FTPD_MAX_RECOVER)
+    ** so leaked-resource accumulation from the documented residual windows
+    ** stays observable in the operator log. */
+    sess->server->total_recover++;
+    if (abcode == 0)
+        ftpd_log_wto("FTPD070E ABEND recovery (ESTAE create failed) "
+                     "cmd=%s socket=%d total=%u",
+                     verb, sess->ctrl_sock, sess->server->total_recover);
+    else if (abcode > 0xFFF)
+        ftpd_log_wto("FTPD070E ABEND S%03X recovered cmd=%s socket=%d "
+                     "total=%u", (abcode >> 12) & 0xFFF, verb,
+                     sess->ctrl_sock, sess->server->total_recover);
+    else
+        ftpd_log_wto("FTPD070E ABEND U%04u recovered cmd=%s socket=%d "
+                     "total=%u", abcode, verb, sess->ctrl_sock,
+                     sess->server->total_recover);
+
+    /* 4. Tell the client before touching in-flight resources, so a
+    ** re-ABEND in cleanup cannot leave it hanging until timeout. */
+    ftpd_session_reply(sess, FTP_451,
+        "Requested action aborted: local error in processing.");
+
+    /* 5. Release the in-flight transfer handle.  Clear the tracking field
+    ** BEFORE closing so a re-ABEND in the close (contained by the caller's
+    ** try()) can never cause a double close on a subsequent recovery.  At
+    ** most one of these is set (a session is in MVS or UFS mode, one
+    ** transfer at a time).  MVS fclose releases the DCB + fopen's SVC 99
+    ** DD; UFS ufs_fclose releases the cross-AS UFSD file. */
+    fp = sess->cur_file;
+    sess->cur_file = NULL;
+    if (fp)
+        fclose(fp);
+
+    if (sess->cur_ufs_file) {
+        UFSFILE *uf = sess->cur_ufs_file;
+        sess->cur_ufs_file = NULL;
+        ufs_fclose(&uf);
+    }
+
+    ftpd_data_close(sess);
+
+    return 0;
+}
+
+/* --------------------------------------------------------------------
 ** Main session loop -- thdmgr worker thread entry point.
 **
 ** This function is called by cthread_worker_wait() with the session
@@ -237,6 +347,8 @@ ftpd_session_run(void *udata, CTHDWORK *work)
     ftpd_session_t *sess = NULL;
     char *data = NULL;
     int rc;
+    int try_rc;
+    int recover_count;
     char cmd[8];
     char *arg;
     char *p;
@@ -269,6 +381,10 @@ ftpd_session_run(void *udata, CTHDWORK *work)
         ftpd_session_reply(sess, FTP_220, "%s", server->config.banner);
         sess->state = SESS_AUTH_USER;
 
+        /* Consecutive per-command ABEND recoveries; reset on any clean
+        ** command so the guard only trips on a wedged session. */
+        recover_count = 0;
+
         /* Command loop */
         while (sess->state != SESS_CLOSING) {
             if (work->state == CTHDWORK_STATE_SHUTDOWN)
@@ -299,9 +415,37 @@ ftpd_session_run(void *udata, CTHDWORK *work)
                 p++;
             arg = p;
 
-            /* Dispatch */
-            rc = ftpd_cmd_dispatch(sess, cmd, arg);
-            if (rc < 0)
+            /* Dispatch under ESTAE recovery.  try() returns the ABEND
+            ** code (0 = clean); the handler's real rc is stashed in
+            ** sess->dispatch_rc.  A negative try_rc means the ESTAE could
+            ** not be created (the command did not run); treat it like a
+            ** recovery so the client is answered and the guard advances. */
+            sess->dispatch_rc = 0;
+            try_rc = try(ftpd_run_command, sess, cmd, arg);
+
+            if (try_rc != 0) {
+                unsigned abcode = (try_rc > 0) ? (unsigned)try_rc : 0;
+
+                recover_count++;
+
+                /* Contain a re-ABEND during recovery itself. */
+                try(ftpd_session_recover, sess, abcode, cmd);
+
+                /* A session that ABENDs every command is wedged (e.g.
+                ** corrupt state); stop recovering and close it cleanly.
+                ** The worker survives and serves the next connection. */
+                if (recover_count >= FTPD_MAX_RECOVER) {
+                    ftpd_log_wto("FTPD071E session socket=%d closed after "
+                                 "%d consecutive ABENDs", sess->ctrl_sock,
+                                 recover_count);
+                    break;
+                }
+                continue;
+            }
+
+            recover_count = 0;
+
+            if (sess->dispatch_rc < 0)
                 break;
         }
 

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -280,7 +280,16 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
     ** lock(asxb)/unlock(asxb) critical section.  MVS DEQs a task's ENQs
     ** at task termination, but recovery keeps the task alive, so an
     ** orphaned AS-wide ENQ would stall every session's racf_auth() until
-    ** this worker's next command.  unlock() is safe when not held. */
+    ** this worker's next command.
+    **
+    ** This is ownership-safe WITHOUT a tracking flag, and cannot break
+    ** racf_auth()'s cross-task serialization (the property #64 relies on):
+    ** unlock() is DEQ RET=HAVE (@@lkunlk.c -> @@enqdeq.c: pl.opt=HAVE,
+    ** SVC 48, returns pl.rc — never ABENDs), and MVS ENQ ownership is
+    ** per-TCB, so a DEQ from THIS task can only release an ENQ THIS task
+    ** owns.  Outside the window (the common case) we don't own it: DEQ
+    ** RET=HAVE returns RC=8 and releases nothing — it can never touch a
+    ** concurrent worker's lock. */
     {
         unsigned *psa  = (unsigned *)0;
         unsigned *ascb = (unsigned *)psa[0x224/4];  /* PSAAOLD  -> ASCB */
@@ -326,6 +335,13 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
     if (sess->cur_ufs_file) {
         UFSFILE *uf = sess->cur_ufs_file;
         sess->cur_ufs_file = NULL;
+        /* KNOWN LIMITATION: ufs_fclose() is a cross-AS request to UFSD
+        ** with no timeout in the libufs API.  If UFSD is dead/hung this
+        ** can BLOCK — the inner try() catches ABENDs, not hangs — and
+        ** wedge the worker.  The 451 was already sent, so the client is
+        ** not left hanging.  This is not worse than normal operation
+        ** (ufsfree() at session teardown would block on a dead UFSD too);
+        ** bounding it needs a timeout that libufs does not yet expose. */
         ufs_fclose(&uf);
     }
 

--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -261,22 +261,44 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
 #ifdef FTPD_DEBUG_ABEND
     /* Debug-only ABEND injection for per-command recovery testing (#63).
     ** NOT compiled into production builds — enable with -DFTPD_DEBUG_ABEND.
-    ** Keyword must be upper-case:
+    ** Requires an authenticated session (SITE is already post-auth; the
+    ** explicit check keeps this from ever being a pre-auth DoS).  Keyword
+    ** must be upper-case:
     **   SITE ABEND        -> ABEND (S0C4) OUTSIDE any lock window; recovery's
     **                        unlock(asxb) must be a no-op and leave every
     **                        concurrent session's racf_auth() undisturbed.
     **   SITE ABEND=LOCK   -> acquire the ASXB ENQ, then ABEND holding it;
     **                        recovery must DEQ the orphaned ENQ (a concurrent
     **                        session parked in racf_auth() then proceeds).
-    ** Both must yield: client gets 451, worker stays up, next command works. */
-    if (strncmp(arg, "ABEND", 5) == 0) {
+    **   SITE ABEND=XFER   -> arm the next MVS RETR to ABEND mid-transfer
+    **                        (cur_file set + data connection open); exercises
+    **                        recovery's fclose(cur_file) + clear-before-close.
+    ** All must yield: client gets 451, worker stays up, next command works.
+    ** NB: S0C4 is a clean program check at a defined instruction; the messier
+    ** realistic cases (S013/S001/S878) are not reproduced here — this proves
+    ** the recovery MECHANISM, not the hardest DCB/buffer states. */
+    if (sess->authenticated && strncmp(arg, "ABEND", 5) == 0) {
         volatile int *trap = (volatile int *)0;
+
+        /* ABEND=XFER: arm, do not ABEND now. */
+        if (arg[5] == '=' && (arg[6] == 'X' || arg[6] == 'x')) {
+            sess->debug_abend_xfer = 1;
+            ftpd_log_wto("FTPD072W DEBUG ABEND=XFER armed socket=%d",
+                         sess->ctrl_sock);
+            ftpd_session_reply(sess, FTP_200,
+                "DEBUG: next RETR will ABEND mid-transfer");
+            return 0;
+        }
+
+        /* ABEND=LOCK: hold the ASXB ENQ across the ABEND. */
         if (arg[5] == '=' && (arg[6] == 'L' || arg[6] == 'l')) {
             unsigned *psa  = (unsigned *)0;
             unsigned *ascb = (unsigned *)psa[0x224/4];
             unsigned *asxb = (unsigned *)ascb[0x6C/4];
-            lock(asxb, 0);              /* hold the ASXB ENQ across the ABEND */
+            lock(asxb, 0);
         }
+
+        /* ABEND (bare) or ABEND=LOCK: fire now. */
         ftpd_log_wto("FTPD072W DEBUG ABEND injection: SITE %s", arg);
         *trap = 0;                     /* force S0C4 */
     }

--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -11,6 +11,9 @@
 #include "ftpd.h"
 #include "ftpd#ses.h"
 #include "ftpd#sit.h"
+#ifdef FTPD_DEBUG_ABEND
+#include "cliblock.h"               /* lock() — debug ABEND injection  */
+#endif
 
 /* --------------------------------------------------------------------
 ** Helper: parse "KEY=VALUE" from token.
@@ -254,6 +257,30 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
             "SITE not necessary; you may proceed");
         return 0;
     }
+
+#ifdef FTPD_DEBUG_ABEND
+    /* Debug-only ABEND injection for per-command recovery testing (#63).
+    ** NOT compiled into production builds — enable with -DFTPD_DEBUG_ABEND.
+    ** Keyword must be upper-case:
+    **   SITE ABEND        -> ABEND (S0C4) OUTSIDE any lock window; recovery's
+    **                        unlock(asxb) must be a no-op and leave every
+    **                        concurrent session's racf_auth() undisturbed.
+    **   SITE ABEND=LOCK   -> acquire the ASXB ENQ, then ABEND holding it;
+    **                        recovery must DEQ the orphaned ENQ (a concurrent
+    **                        session parked in racf_auth() then proceeds).
+    ** Both must yield: client gets 451, worker stays up, next command works. */
+    if (strncmp(arg, "ABEND", 5) == 0) {
+        volatile int *trap = (volatile int *)0;
+        if (arg[5] == '=' && (arg[6] == 'L' || arg[6] == 'l')) {
+            unsigned *psa  = (unsigned *)0;
+            unsigned *ascb = (unsigned *)psa[0x224/4];
+            unsigned *asxb = (unsigned *)ascb[0x6C/4];
+            lock(asxb, 0);              /* hold the ASXB ENQ across the ABEND */
+        }
+        ftpd_log_wto("FTPD072W DEBUG ABEND injection: SITE %s", arg);
+        *trap = 0;                     /* force S0C4 */
+    }
+#endif
 
     warn[0] = '\0';
     n_tokens = 0;

--- a/src/ftpd#ufs.c
+++ b/src/ftpd#ufs.c
@@ -443,11 +443,15 @@ ftpd_ufs_retr(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Track for ABEND recovery (releases the cross-AS UFSD file). */
+    sess->cur_ufs_file = fp;
+
     // Open data connection
     ftpd_session_reply(sess, FTP_150,
                        "Opening data connection for %s", path);
     if (ftpd_data_open(sess) != 0) {
         ftpd_session_reply(sess, FTP_425, "Cannot open data connection");
+        sess->cur_ufs_file = NULL;
         ufs_fclose(&fp);
         return 0;
     }
@@ -462,6 +466,7 @@ ftpd_ufs_retr(ftpd_session_t *sess, const char *arg)
             break;
     }
 
+    sess->cur_ufs_file = NULL;
     ufs_fclose(&fp);
     ftpd_data_close(sess);
     ftpd_session_reply(sess, FTP_226, "Transfer complete");
@@ -504,11 +509,15 @@ ftpd_ufs_stor(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Track for ABEND recovery (releases the cross-AS UFSD file). */
+    sess->cur_ufs_file = fp;
+
     // Open data connection
     ftpd_session_reply(sess, FTP_150,
                        "Opening data connection for %s", path);
     if (ftpd_data_open(sess) != 0) {
         ftpd_session_reply(sess, FTP_425, "Cannot open data connection");
+        sess->cur_ufs_file = NULL;
         ufs_fclose(&fp);
         return 0;
     }
@@ -522,6 +531,7 @@ ftpd_ufs_stor(ftpd_session_t *sess, const char *arg)
         ufs_fwrite(buf, 1, (UINT32)n, fp);
     }
 
+    sess->cur_ufs_file = NULL;
     ufs_fclose(&fp);
     ftpd_data_close(sess);
     ftpd_session_reply(sess, FTP_226, "Transfer complete");

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -181,6 +181,14 @@ initialize(ftpd_server_t *server, int argc, char **argv)
         }
     }
 
+    /* Capture the STC identity ACEE now, before any worker subtask is
+    ** attached.  racf_set_acee() stores into the address-space-wide
+    ** ASXBSENV, so this is the AS's normal resting identity; ABEND
+    ** recovery resets ASXBSENV to it so a worker never continues under
+    ** a user (or freed) ACEE after an unexpected ABEND.  May be NULL if
+    ** RACINIT above failed — that is still the correct value to restore. */
+    server->stc_acee = racf_get_acee();
+
     /* Initialize trace ring buffer */
     ftpd_trace_init(512);
 


### PR DESCRIPTION
Closes #63.

Adds an ESTAE-style recovery boundary around **per-command** processing so a
single unexpected ABEND aborts only the current command instead of killing the
worker subtask and dropping the client. Defense-in-depth over the
`check_dataset_access()` / ACEE pre-checks from #61 — a RAKF denial still returns
a clean `550` and never reaches recovery.

## What changed

- **`ftpd#ses.c`** — wrap per-command dispatch in `try()`. `try()` returns the
  ABEND code and discards the wrapped function's rc, so a thin `ftpd_run_command`
  wrapper stashes the dispatcher's rc in `sess->dispatch_rc` (preserving the
  `-1`→break for QUIT/auth-failure). `ftpd_session_recover()` runs the cleanup;
  a `FTPD_MAX_RECOVER` consecutive-recovery guard closes a wedged session cleanly
  (worker survives, serves the next client).
- **`ftpd.c`** — capture `server->stc_acee = racf_get_acee()` once at init,
  before any worker subtask is attached.
- **`ftpd#mvs.c` / `ftpd#ufs.c`** — track the in-flight transfer handle
  (`cur_file` for MVS RETR/STOR/APPE, `cur_ufs_file` for UFS RETR/STOR); cleared
  **before** close for idempotency.
- **`doc/FTPD_RAKF_SETUP.md`** — SECURITY INVARIANT: `FTPD/USER` must stay
  least-privilege (see below).

## Recovery handler ordering (deliberate)

The handler runs under `try()` itself, so a cleanup re-ABEND is contained. Order:

1. `racf_set_acee(stc_acee)` — reset the **AS-wide** ASXBSENV to the STC identity.
2. `unlock(asxb)` — release the ASXB ENQ if the ABEND struck inside
   `racf_auth()`'s `lock()` critical section (see finding).
3. WTO decoded ABEND (`Sxxx`/`Uxxxx`) + command, then `451` to the client —
   both **before** the one genuinely risky step.
4. `fclose`/`ufs_fclose` the transfer handle, then close the data connection.

## Mechanism (why the handler can use ordinary services)

crent370's `try()` is **SDWA-retry that unwinds the stack back to the `try()`
frame and resumes in normal task mode** (`libc370/src/clib/@@@try.c`), so the
`if (abrc)` branch runs on a valid stack — `fclose`/`racf_set_acee`/`send`/WTO
are all legal — and the heap-allocated session struct survives.

## Point-D finding — `racf_auth()` and the ACEE race

`racf_auth(ACEE*, …)` (`libc370/src/racf/racauth.c`) takes the identity
explicitly but plumbs it through the **address-space-wide** ASXBSENV (RACHECK
samples that field), wrapping set/RACHECK/restore in `lock(asxb)`/`unlock(asxb)`.
That ENQ serializes concurrent `racf_auth()` calls, so **the primary
authorization decision — FTPD's `check_dataset_access()` pre-check before every
security-relevant `fopen` — is race-free.** The residual race is the
*unserialized* OPEN-path `racf_set_acee(sess->acee)/fopen/restore` switch, whose
worst case for a pre-checked open is a spurious OPEN failure (availability), not
escalation. Severity: **hardening / defense-in-depth**. Tracked, verify-first,
in **#64** — not fixed here.

Consequence surfaced by this change: `lock()`/`unlock()` are TCB-level MVS ENQs
auto-DEQ'd at task termination. Because recovery keeps the TCB alive, an ABEND
inside `racf_auth()`'s critical section would orphan the AS-wide ASXB ENQ and
stall every session's authorization — hence the defensive `unlock(asxb)` in the
handler (safe when not held).

## SECURITY INVARIANT

Recovery's ASXBSENV reset is fail-closed **only while `FTPD/USER` is
least-privilege**: a concurrent session transiently pulled onto that identity can
only lose authority, never gain it. If `FTPD/USER` is granted broad dataset
authority the reset degrades to fail-open. Documented as an invariant in
`doc/FTPD_RAKF_SETUP.md §5.1`.

## Scope / documented residuals

Handle tracking is on the transfer paths only. **Not** instrumented (documented
residuals): metadata `fopen`s (SIZE/LIST/MDTM); the STOR `__dsalcf`/`__dsfree`
window (leaks the DD **and** an empty catalogued dataset); STOR-binary's
`record_buffer`. `total_recover` in the operator log (`FTPD070E … total=n`) makes
any accumulation observable.

## Verification

- ✅ **Build-verified only:** clean `-Wall -Werror` cc370 build (`make modules`).
  New operator messages `FTPD070E` (recovery) and `FTPD071E` (guard-close)
  checked against existing numbers — no collision.
- ⏳ **Behavioral verification pending on MVS/CE + TK5** (not yet exercised):
  - trigger a recoverable ABEND → client gets `451`, worker stays up, next
    command works, and a subsequent RAKF denial still shows the correct user
    identity (proves ASXBSENV was restored);
  - regression: normal RETR/STOR/LIST/JES unaffected; RAKF denials still produce
    a clean `550` (recovery not triggered on the happy-denial path).

ABEND recovery cannot be meaningfully unit-tested on the host; the runtime proof
above is the acceptance gate.
