### PR TITLE
Answer 550 when RETR asks for a spool file the job does not have (#70)

### DIFF
--- a/src/ftpd#jes.c
+++ b/src/ftpd#jes.c
@@ -734,15 +734,22 @@ ftpd_jes_retrieve(ftpd_session_t *sess, const char *arg)
                 }
             }
         }
-        if (target_dd) {
-            ftpd_session_reply(sess, FTP_125,
-                "Sending data set %s.%s.%s.D%07d.%s",
-                job->owner, job->jobname, job->jobid,
-                target_dd->dsid, target_dd->ddname);
-        } else {
-            ftpd_session_reply(sess, FTP_125,
-                "Sending spool file %d for %s", dsid_req, jobid_arg);
+        /* An index past the last spool file (or 0 -- DD numbering starts at
+        ** 1) has nothing to send.  Say so before the 125: announcing a data
+        ** set and then completing an empty transfer claims the spool file
+        ** exists and is empty, which is a different answer. */
+        if (!target_dd) {
+            jesjobfr(&joblist);
+            ftpd_session_reply(sess, FTP_550,
+                "Spool file %d not found for Jobid %s, %d spool file(s) available",
+                dsid_req, jobid_arg, idx);
+            return 0;
         }
+
+        ftpd_session_reply(sess, FTP_125,
+            "Sending data set %s.%s.%s.D%07d.%s",
+            job->owner, job->jobname, job->jobid,
+            target_dd->dsid, target_dd->ddname);
     }
 
     if (ftpd_data_open(sess) != 0) {


### PR DESCRIPTION
`RETR JOBnnnnn.n` löste den 1-basierten Index bisher nur auf, um die `125`-Antwort zu bauen, und fiel auf ein generisches `125 Sending spool file n` zurück, wenn der Index nichts traf. Die Transferschleife fand dann kein passendes `dd_index`, schickte nichts und schloss mit `250 Transfer completed successfully` ab — eine leere Datei plus die Behauptung, alles sei in Ordnung.

Auf dem Ziel gemessen (mvsdev, `JOB00326` mit zwei Spool-Files):

```
RETR JOB00326.9: lines=0 reply=250 Transfer completed successfully.
```

## Änderung

Der Index wird jetzt aufgelöst, **bevor** irgendetwas angekündigt wird. Trifft er kein sichtbares Spool-File — hinter dem letzten, oder `0`, denn die DD-Nummerierung beginnt bei 1 — lautet die Antwort:

```
550 Spool file 9 not found for Jobid JOB00326, 2 spool file(s) available
```

Weder `125` noch Datenverbindung. Der Pfad mit gültigem Index ist unverändert (`125 Sending data set owner.jobname.jobid.Dseqno.ddname`).

## Verifikation

`make clean && make` sauber (`-Wall -Werror`). Zieltest folgt, sobald das Modul auf mvsdev läuft — geprüft werden dann: gültiger Index (`.1` → 125 + Daten + 250), zu hoher Index (`.9` → 550), `.0` → 550, und alle Spool-Files ohne Index (unverändert 250).

Closes #70

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk