### PR TITLE
Add the missing HASPACE1 DD to the sample STC procedure

### DIFF
--- a/samplib/ftpd
+++ b/samplib/ftpd
@@ -23,4 +23,13 @@
 //STDOUT   DD  SYSOUT=*
 //STDERR   DD  SYSOUT=*
 //FTPDPRM  DD  DSN=&D(&M),DISP=SHR,FREE=CLOSE
-//HASPCKPT DD  DISP=SHR,DSN=SYS1.HASPCKPT
+//*
+//* JES mode (SITE FILETYPE=JES) needs BOTH the checkpoint and the
+//* spool dataset: jesopen() opens DD:HASPCKPT and DD:HASPACE1.
+//* Without HASPACE1 every JES command answers 451 and the STC log
+//* shows IEC130I HASPACE1 DD STATEMENT MISSING.
+//* UNIT and VOL are site specific -- use the volumes your JES2
+//* checkpoint and spool datasets actually live on.
+//*
+//HASPCKPT DD  DISP=SHR,DSN=SYS1.HASPCKPT,UNIT=3350,VOL=SER=MVS000
+//HASPACE1 DD  DISP=SHR,DSN=SYS1.HASPACE,UNIT=3350,VOL=SER=SPOOL1


### PR DESCRIPTION
`samplib/ftpd` deklarierte nur `HASPCKPT`. Ein daraus installiertes System hat damit keinen funktionierenden JES-Modus: `jesopen()` öffnet `DD:HASPCKPT` **und** `DD:HASPACE1` (`libc370/src/jes/jesopen.c:36` bzw. `:46`). Fehlt die zweite DD, antwortet jeder `SITE FILETYPE=JES`-Befehl mit `451 Unable to open JES checkpoint`, und im STC-Log steht `IEC130I HASPACE1 DD STATEMENT MISSING`.

Genau so gefunden beim Zieltest zu #68: der FTPD-Proc auf dem Testsystem stammt aus diesem Sample. Der HTTPD-Proc im httpd-Repo führt beide DDs seit jeher — hier war es schlicht vergessen.

```
//HASPCKPT DD  DISP=SHR,DSN=SYS1.HASPCKPT,UNIT=3350,VOL=SER=MVS000
//HASPACE1 DD  DISP=SHR,DSN=SYS1.HASPACE,UNIT=3350,VOL=SER=SPOOL1
```

UNIT/VOL sind standortabhängig (die Datasets liegen üblicherweise unkatalogisiert auf dem Spool-Volume); ein Kommentar im Sample sagt das jetzt dazu. Die gezeigten Werte sind die des Testsystems und entsprechen dem HTTPD-Sample.

Nur JCL im Sample, kein Code.

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk