### PR TITLE
Refuse a second FTPD on a port that is already served (#8)

### DIFF
--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -131,6 +131,11 @@ typedef struct ftpd_alloc {
 typedef struct ftpd_session ftpd_session_t;
 typedef struct ftpd_server  ftpd_server_t;
 
+/* Major name of the single-instance ENQ (SCOPE=SYSTEM).  The minor name
+** carries the listen port, so one FTPD per port is allowed and a second
+** start on a port already served is refused. */
+#define FTPD_ENQ_QNAME      "FTPD"
+
 /* --- Global server state --- */
 struct ftpd_server {
     char            eye[8];         /* eye catcher                   */
@@ -142,6 +147,9 @@ struct ftpd_server {
 #define FTPD_QUIESCE        0x02    /* shutdown in progress          */
 
     ftpd_config_t   config;         /* server configuration          */
+    char            enq_rname[16];  /* "FTPD.PORT.nnnnn": the single
+                                    ** instance ENQ, held by main's TCB
+                                    ** for the life of the server      */
     ACEE            *stc_acee;      /* STC identity ACEE, captured at
                                     ** init; recovery resets ASXBSENV
                                     ** to this after an ABEND          */

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -218,9 +218,11 @@ initialize(ftpd_server_t *server, int argc, char **argv)
     rc = ENQ(FTPD_ENQ_QNAME, server->enq_rname,
              ENQ_SYSTEM | ENQ_EXC | ENQ_USE);
     if (rc != 0) {
-        ftpd_log_wto("FTPD002E FTPD is already active on port %d "
-                     "(ENQ rc=%d), this instance ends",
-                     server->config.port, rc);
+        /* rc=4 is the expected "another address space holds it"; anything
+        ** else goes to the trace, the operator message stays plain. */
+        ftpd_trace("startup ENQ %s rc=%d", server->enq_rname, rc);
+        ftpd_log_wto("FTPD002E FTPD is already active on port %d, "
+                     "this instance ends", server->config.port);
         return 8;
     }
 

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -13,6 +13,7 @@
 #include "ftpd#ses.h"
 #include "clibppa.h"
 #include "clibos.h"
+#include "clibenq.h"
 
 /* Global server state */
 ftpd_server_t *ftpd_server = NULL;
@@ -195,6 +196,32 @@ initialize(ftpd_server_t *server, int argc, char **argv)
     /* Load configuration from DD:FTPDPRM */
     if (ftpdcfg_load(&server->config) != 0) {
         return 4;
+    }
+
+    /* Refuse a second instance on the same port.
+    **
+    ** Without this, /S FTPD on an already running server starts a complete
+    ** second one: both bind the listen port (the newcomer closes the first
+    ** server's socket as stale) and both answer MODIFY, so every console
+    ** command is processed twice.
+    **
+    ** The resource is keyed by port, so a deliberate second server on
+    ** another port (/S FTPD,M=FTPDPRM1) still starts.  RET=USE takes the
+    ** resource when it is free and returns rc=4 instead of waiting when
+    ** another address space holds it.  The ENQ belongs to main's TCB and
+    ** MVS releases it at task end -- including after an ABEND -- so there
+    ** is no DEQ to forget and no stale lock to clean up.
+    */
+    snprintf(server->enq_rname, sizeof(server->enq_rname),
+             "FTPD.PORT.%05d", server->config.port);
+
+    rc = ENQ(FTPD_ENQ_QNAME, server->enq_rname,
+             ENQ_SYSTEM | ENQ_EXC | ENQ_USE);
+    if (rc != 0) {
+        ftpd_log_wto("FTPD002E FTPD is already active on port %d "
+                     "(ENQ rc=%d), this instance ends",
+                     server->config.port, rc);
+        return 8;
     }
 
     /* Create socket thread (handles listener + accept loop) */


### PR DESCRIPTION
`/S FTPD` auf einem bereits laufenden Server startete bisher eine vollständige zweite Instanz: beide banden den Listen-Port (die neue schloss den Socket der ersten als „stale"), und beide beantworteten MODIFY — jedes Konsolkommando wurde doppelt ausgeführt.

## Änderung

`initialize()` nimmt nach dem Laden der Config einen exklusiven ENQ:

```
QNAME  FTPD
RNAME  FTPD.PORT.nnnnn      (nnnnn = konfigurierter Port)
       SCOPE=SYSTEM, RET=USE, exklusiv
```

`RET=USE` nimmt die Resource, wenn sie frei ist, und liefert `rc=4` statt zu warten, wenn ein anderer Adressraum sie hält. Eine doppelte Instanz endet dann mit

```
FTPD002E FTPD is already active on port 2121 (ENQ rc=4), this instance ends
```

und RC=8 — bevor ein Socket oder ein Thread existiert.

Der Minor Name trägt den Port, also startet der bewusst zweite Server auf einem anderen Port (`/S FTPD,M=FTPDPRM1`, im Sample-Proc dokumentiert) weiterhin. Der ENQ gehört dem TCB von `main`; MVS gibt ihn bei Task-Ende frei, auch nach ABEND — kein DEQ, das man vergessen kann, kein hängender Lock.

## Zu den Optionen im Issue

- **Name/Token (IEANTRT):** existiert auf MVS 3.8j nicht, das ist ein z/OS-Service.
- **Port-Check über bind():** sieht nur den Kollisionsfall und ist ein Rennen mit der zweiten Instanz.
- **ENQ:** SVC 56, in libc370 als `ENQ()`/`clibenq.h` vorhanden.

## Verifikation

`make clean && make` sauber (`-Wall -Werror`). Der Zieltest steht noch aus: FTPD starten, dann ein zweites `/S FTPD` absetzen — erwartet werden FTPD002E + RC=8 für die zweite Instanz, während die erste ungestört weiterläuft.

Ein Punkt, den dieser Test mitentscheidet: `__enqdeq()` in libc370 liest den Return Code aus Byte 3 der Parameterliste und nicht aus R15. Für Einzel-Resource-Requests dokumentiert IBM R15 als Ablageort. Startet die zweite Instanz trotzdem durch, liegt der Fehler dort — und beträfe dann auch `trylock()`/`testlock()`.

Closes #8

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk