### PR TITLE
Optionally acknowledge PBSZ/PROT for TLS-terminating proxies (#59)

### DIFF
--- a/include/ftpd#cfg.h
+++ b/include/ftpd#cfg.h
@@ -27,6 +27,11 @@ typedef struct ftpd_config {
 
     /* Security */
     char            authuser[9];    /* user allowed to TERM server   */
+    int             sslproxy;       /* 1 = acknowledge PBSZ/PROT with
+                                    ** 200 although FTPD encrypts
+                                    ** nothing.  Only correct behind a
+                                    ** TLS terminating proxy -- see
+                                    ** SSLPROXY in the sample config  */
 
     /* JES */
     int             jes_level;      /* default JES interface level   */

--- a/samplib/ftpdprm0
+++ b/samplib/ftpdprm0
@@ -18,6 +18,26 @@ MAXSESSIONS=10
 IDLETIMEOUT=300
 BANNER=MVS 3.8j FTPD Server
 #
+# --- TLS terminating proxy ---
+#
+# MVS 3.8j has no TLS, so FTPD cannot offer FTPS itself.  The way around
+# that is a proxy (HAProxy, stunnel, ...) that terminates TLS and talks
+# plaintext to FTPD.  For the DATA connection to be encrypted as well the
+# client must see PBSZ/PROT answered with 200 -- any other answer makes it
+# open the data connection in the clear, against a proxy that waits for a
+# handshake, and the transfer dies in a timeout.
+#
+# SSLPROXY=YES answers PBSZ and PROT P/C with 200 and lists both in FEAT.
+# FTPD still encrypts NOTHING; the proxy does.
+#
+# Only turn this on when a terminating proxy is guaranteed in front of
+# FTPD and FTPD is not reachable directly -- bind it to the private
+# interface with SRVIP.  Run bare, it promises clients a confidentiality
+# it does not deliver.  AUTH TLS (explicit FTPS) stays 504 either way;
+# this is for implicit FTPS.
+#
+SSLPROXY=NO
+#
 # --- JES ---
 JESINTERFACELEVEL=2
 #

--- a/src/ftpd#cfg.c
+++ b/src/ftpd#cfg.c
@@ -33,6 +33,7 @@ ftpdcfg_defaults(ftpd_config_t *cfg)
 
     /* Security */
     memset(cfg->authuser, 0, sizeof(cfg->authuser));
+    cfg->sslproxy = 0;              /* off: PBSZ/PROT stay unimplemented */
 
     /* JES */
     cfg->jes_level = 2;
@@ -178,6 +179,20 @@ parse_keyvalue(ftpd_config_t *cfg, const char *key, const char *value)
     else if (strcmp(key, "AUTHUSER") == 0) {
         strncpy(cfg->authuser, value, sizeof(cfg->authuser) - 1);
     }
+    else if (strcmp(key, "SSLPROXY") == 0) {
+        /* YES makes FTPD answer PBSZ/PROT with 200 without encrypting
+        ** anything -- correct only when a TLS terminating proxy is in
+        ** front of it.  Anything but YES leaves the option off. */
+        if (strcmp(value, "YES") == 0 || strcmp(value, "yes") == 0) {
+            cfg->sslproxy = 1;
+        } else if (strcmp(value, "NO") == 0 || strcmp(value, "no") == 0) {
+            cfg->sslproxy = 0;
+        } else {
+            ftpd_log(LOG_WARN, "%s: SSLPROXY must be YES or NO, "
+                     "got %s, staying off", __func__, value);
+            cfg->sslproxy = 0;
+        }
+    }
     else if (strcmp(key, "JESINTERFACELEVEL") == 0) {
         cfg->jes_level = atoi(value);
         if (cfg->jes_level < 1 || cfg->jes_level > 2)
@@ -294,6 +309,8 @@ ftpdcfg_dump(const ftpd_config_t *cfg)
     ftpd_log_wto("FTPD043I   MAXSESSIONS=%d IDLETIMEOUT=%d",
                  cfg->max_sessions, cfg->idle_timeout);
     ftpd_log_wto("FTPD044I   BANNER=%s", cfg->banner);
+    ftpd_log_wto("FTPD049I   SSLPROXY=%s",
+                 cfg->sslproxy ? "YES" : "NO");
     ftpd_log_wto("FTPD045I   DEFRECFM=%s DEFLRECL=%d DEFBLKSIZE=%d",
                  cfg->defaults.recfm, cfg->defaults.lrecl,
                  cfg->defaults.blksize);

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -78,10 +78,59 @@ cmd_feat(ftpd_session_t *sess)
         " SITE FILETYPE\r\n"
         " SITE JES\r\n"
         " UTF8\r\n"
-        "211 End\r\n");
+        /* A client that reads FEAT before sending PROT skips it when
+        ** the feature is absent, so announce both only when SSLPROXY
+        ** makes them answerable. */
+        "%s"
+        "211 End\r\n",
+        sess->server->config.sslproxy ? " PBSZ\r\n PROT\r\n" : "");
     for (i = 0; i < len; i++)
         buf[i] = ebc2asc[(unsigned char)buf[i]];
     send(sess->ctrl_sock, buf, len, 0);
+    return 0;
+}
+
+/* --------------------------------------------------------------------
+** cmd_pbsz / cmd_prot -- RFC 4217 protection commands, SSLPROXY only.
+**
+** FTPD encrypts nothing -- MVS 3.8j has no TLS.  With SSLPROXY=YES a TLS
+** terminating proxy sits in front of it and the client must be told that
+** protection is available: any non-2xx answer makes it open the data
+** connection in the clear, against a proxy that waits for a handshake,
+** and the transfer dies in a timeout.  Without the option both commands
+** stay unimplemented and fall through to 500.
+** ----------------------------------------------------------------- */
+static int
+cmd_pbsz(ftpd_session_t *sess, const char *arg)
+{
+    (void)arg;                  /* over TLS the buffer size is always 0 */
+    ftpd_session_reply(sess, FTP_200, "PBSZ=0");
+    return 0;
+}
+
+static int
+cmd_prot(ftpd_session_t *sess, const char *arg)
+{
+    char lvl;
+
+    if (!arg || !arg[0]) {
+        ftpd_session_reply(sess, FTP_501,
+                           "PROT requires a protection level");
+        return 0;
+    }
+
+    lvl = (char)toupper((unsigned char)arg[0]);
+
+    /* P (private) is what the proxy provides; C (clear) is the client
+    ** turning protection off again.  S and E have no meaning here. */
+    if (lvl == 'P' || lvl == 'C') {
+        ftpd_session_reply(sess, FTP_200,
+                           "Data channel protection level set to %c", lvl);
+        return 0;
+    }
+
+    ftpd_session_reply(sess, FTP_504,
+                       "Protection level %c not supported", lvl);
     return 0;
 }
 
@@ -267,6 +316,12 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
             ftpd_session_reply(sess, FTP_504,
                 "Security mechanism not implemented.");
             return 0;
+        }
+        /* RFC 2228 allows PBSZ/PROT before login, and clients send them
+        ** there -- 530 would read as "no protection" just like 500. */
+        if (sess->server->config.sslproxy) {
+            if (strcmp(cmd, "PBSZ") == 0) return cmd_pbsz(sess, arg);
+            if (strcmp(cmd, "PROT") == 0) return cmd_prot(sess, arg);
         }
 
         ftpd_session_reply(sess, FTP_530, "Not logged in.");
@@ -491,6 +546,10 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
         ftpd_session_reply(sess, FTP_504,
             "Security mechanism not implemented.");
         return 0;
+    }
+    if (sess->server->config.sslproxy) {
+        if (strcmp(cmd, "PBSZ") == 0) return cmd_pbsz(sess, arg);
+        if (strcmp(cmd, "PROT") == 0) return cmd_prot(sess, arg);
     }
 
     /* Unknown command */

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -198,6 +198,17 @@ initialize(ftpd_server_t *server, int argc, char **argv)
         return 4;
     }
 
+    /* SSLPROXY makes FTPD claim data channel protection it does not
+    ** provide.  That is only true behind a TLS terminating proxy, so the
+    ** operator gets told at every start -- a server reachable directly
+    ** with this on promises its clients confidentiality it has not got. */
+    if (server->config.sslproxy) {
+        ftpd_log_wto("FTPD005W SSLPROXY=YES: PBSZ/PROT are acknowledged "
+                     "but FTPD encrypts nothing");
+        ftpd_log_wto("FTPD005W A TLS terminating proxy must be in front "
+                     "of port %d", server->config.port);
+    }
+
     /* Refuse a second instance on the same port.
     **
     ** Without this, /S FTPD on an already running server starts a complete


### PR DESCRIPTION
MVS 3.8j hat kein TLS, FTPS geht also nur mit einem Proxy davor (HAProxy, stunnel), der TLS terminiert und im Klartext mit FTPD spricht. `PASVADR`/`PASVPORTS` decken die passive Hälfte ab; die Datenverbindung blieb bisher unverschlüsselt, weil `PBSZ`/`PROT` auf `500 unknown command` durchfielen — und ein Client, der auf `PROT` etwas anderes als 2xx bekommt, öffnet die Datenverbindung im Klartext gegen einen Proxy, der einen Handshake erwartet.

## Änderung

`SSLPROXY=YES` (Default `NO`):

| Kommando | Antwort |
|---|---|
| `PBSZ …` | `200 PBSZ=0` |
| `PROT P` / `PROT C` | `200 Data channel protection level set to P\|C` |
| `PROT` ohne Level | `501 PROT requires a protection level` |
| `PROT S` / `E` | `504 Protection level x not supported` |
| `FEAT` | listet zusätzlich ` PBSZ` und ` PROT` |

Beide Kommandos werden auch **vor** dem Login beantwortet — RFC 2228 erlaubt das, und Clients senden sie dort; ein `530` liest sich für den Client genauso wie ein `500`. FTPD verschlüsselt nichts, das macht der Proxy. `AUTH` bleibt `504`: das hier ist implizites FTPS, explizites `AUTH TLS` kann so nicht funktionieren (#34).

Weil die Option den Server Schutz behaupten lässt, den er nicht leistet, ist sie aus per Default, warnt bei jedem Start zweimal auf der Konsole (`FTPD005W`), taucht im CONFIG-Dump auf (`FTPD049I`), und `samplib/ftpdprm0` schreibt dazu, dass ein terminierender Proxy garantiert davor stehen muss und FTPD über `SRVIP` auf die private Schnittstelle gehört.

## Auf dem Ziel verifiziert (mvsdev, zwei Neustarts)

**Ohne `SSLPROXY` im Member (Default):**

```
FEAT     : 211- ... UTF8 / 211 End          (kein PBSZ, kein PROT)
PBSZ 0   : 530 Not logged in.               (pre-auth)
PBSZ 0   : 500 unknown command PBSZ         (authentifiziert)
PROT P   : 500 unknown command PROT
AUTH TLS : 504 Security mechanism not implemented.
```

**Mit `SSLPROXY=YES`:**

```
FEAT     : 211- ... UTF8 / PBSZ / PROT / 211 End    (pre-auth wie authentifiziert)
PBSZ 0   : 200 PBSZ=0                                (pre-auth wie authentifiziert)
PBSZ     : 200 PBSZ=0
PROT P   : 200 Data channel protection level set to P
PROT C   : 200 Data channel protection level set to C
PROT S   : 504 Protection level S not supported
PROT     : 501 PROT requires a protection level
AUTH TLS : 504 Security mechanism not implemented.
LIST     : 226 List completed successfully. (12 Zeilen)
```

Das Testsystem-Member ist wieder im Originalzustand. Nicht getestet, weil auf dem Testsystem kein Proxy steht: der Ende-zu-Ende-Fall mit echtem TLS-Handshake auf der Datenverbindung — den hat das Issue mit dem Shim bereits nachgewiesen, hier ging es um die Antworten von FTPD.

Closes #59

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk