### PR TITLE
Let the passive listener bind an address other than 0.0.0.0 (#60)

### DIFF
--- a/include/ftpd#cfg.h
+++ b/include/ftpd#cfg.h
@@ -18,6 +18,11 @@ typedef struct ftpd_config {
     int             port;           /* listen port (default 21)      */
     char            bind_ip[16];    /* bind IP ("ANY" = 0.0.0.0)    */
     char            pasv_addr[16];  /* PASV address for responses    */
+    char            pasv_bind[16];  /* passive listener bind address
+                                    ** ("ANY" = 0.0.0.0).  NOT the same
+                                    ** as pasv_addr: this is where FTPD
+                                    ** listens, that is what the client
+                                    ** is told to connect to           */
     int             pasv_lo;        /* PASV port range low           */
     int             pasv_hi;        /* PASV port range high          */
     /* Limits */

--- a/samplib/ftpdprm0
+++ b/samplib/ftpdprm0
@@ -13,6 +13,15 @@ SRVIP=ANY
 PASVADR=127,0,0,1
 PASVPORTS=22000-22200
 #
+# PASVBIND is where the passive listener binds, PASVADR is what the
+# client is told to connect to -- they are only the same by default.
+# ANY (the default) binds every address of the host, as before.
+# Set one address when something else must own those ports on the
+# public address, e.g. a TLS terminating proxy that forwards to FTPD:
+#   PASVBIND=127.0.0.1     FTPD listens on loopback
+#   PASVADR=203,0,113,10   client is sent to the proxy
+PASVBIND=ANY
+#
 # --- Limits ---
 MAXSESSIONS=10
 IDLETIMEOUT=300

--- a/src/ftpd#cfg.c
+++ b/src/ftpd#cfg.c
@@ -24,6 +24,7 @@ ftpdcfg_defaults(ftpd_config_t *cfg)
     cfg->port = 2121;
     strcpy(cfg->bind_ip, "ANY");
     strcpy(cfg->pasv_addr, "127.0.0.1");
+    strcpy(cfg->pasv_bind, "ANY");  /* bind every address, as before */
     cfg->pasv_lo = 22000;
     cfg->pasv_hi = 22200;
     /* Limits */
@@ -151,6 +152,31 @@ parse_keyvalue(ftpd_config_t *cfg, const char *key, const char *value)
                 buf[i] = '.';
         }
         strcpy(cfg->pasv_addr, buf);
+    }
+    else if (strcmp(key, "PASVBIND") == 0) {
+        /* Where the passive listener binds -- ANY or one address.  A
+        ** co-located TLS proxy owns the public address on the same
+        ** ports, so FTPD must be able to stay off it. */
+        char buf[16];
+        int i;
+        strncpy(buf, value, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        for (i = 0; buf[i]; i++) {
+            if (buf[i] == ',')
+                buf[i] = '.';
+        }
+        if (strcmp(buf, "ANY") == 0 || strcmp(buf, "any") == 0) {
+            strcpy(cfg->pasv_bind, "ANY");
+        } else {
+            unsigned b1, b2, b3, b4;
+            if (sscanf(buf, "%u.%u.%u.%u", &b1, &b2, &b3, &b4) == 4) {
+                strcpy(cfg->pasv_bind, buf);
+            } else {
+                ftpd_log(LOG_WARN, "%s: invalid PASVBIND %s, using ANY",
+                         __func__, value);
+                strcpy(cfg->pasv_bind, "ANY");
+            }
+        }
     }
     else if (strcmp(key, "PASVPORTS") == 0) {
         /* Format: low-high */
@@ -304,8 +330,9 @@ ftpdcfg_dump(const ftpd_config_t *cfg)
 
     ftpd_log_wto("FTPD040I Configuration:");
     ftpd_log_wto("FTPD041I   SRVPORT=%d SRVIP=%s", cfg->port, cfg->bind_ip);
-    ftpd_log_wto("FTPD042I   PASVADR=%s PASVPORTS=%d-%d",
-                 cfg->pasv_addr, cfg->pasv_lo, cfg->pasv_hi);
+    ftpd_log_wto("FTPD042I   PASVADR=%s PASVPORTS=%d-%d PASVBIND=%s",
+                 cfg->pasv_addr, cfg->pasv_lo, cfg->pasv_hi,
+                 cfg->pasv_bind);
     ftpd_log_wto("FTPD043I   MAXSESSIONS=%d IDLETIMEOUT=%d",
                  cfg->max_sessions, cfg->idle_timeout);
     ftpd_log_wto("FTPD044I   BANNER=%s", cfg->banner);

--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -42,6 +42,51 @@ ftpd_data_port(ftpd_session_t *sess, const char *arg)
 ** Sends 227 response with address:port.
 ** Returns 0 on success, -1 on error.
 ** ----------------------------------------------------------------- */
+/* --------------------------------------------------------------------
+** Bind a passive listener to a free port in the configured range.
+**
+** The bind address is PASVBIND, which is deliberately NOT PASVADR:
+** PASVADR is the address the client is told to connect to, PASVBIND is
+** where FTPD actually listens.  They differ when a TLS terminating proxy
+** owns the public address on the same ports and forwards to FTPD on
+** loopback -- binding INADDR_ANY would take those ports on every address
+** of the host and lock the proxy out.
+**
+** Returns the bound port, or -1 when the whole range is taken.
+** ----------------------------------------------------------------- */
+static int
+bind_pasv_port(ftpd_session_t *sess, int sock)
+{
+    struct sockaddr_in addr;
+    unsigned bindaddr = 0;          /* INADDR_ANY */
+    const char *pb = sess->server->config.pasv_bind;
+    unsigned b1, b2, b3, b4;
+    int port;
+
+    if (pb[0] && strcmp(pb, "ANY") != 0 &&
+        sscanf(pb, "%u.%u.%u.%u", &b1, &b2, &b3, &b4) == 4) {
+        bindaddr = htonl((b1 << 24) | (b2 << 16) | (b3 << 8) | b4);
+    }
+
+    for (port = sess->server->config.pasv_lo;
+         port <= sess->server->config.pasv_hi;
+         port++) {
+
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = bindaddr;
+        addr.sin_port = htons(port);
+
+        if (bind(sock, &addr, sizeof(addr)) == 0)
+            return port;
+    }
+
+    ftpd_log(LOG_ERROR, "%s: no port available in range %d-%d on %s",
+             __func__, sess->server->config.pasv_lo,
+             sess->server->config.pasv_hi, pb);
+    return -1;
+}
+
 int
 ftpd_data_pasv(ftpd_session_t *sess)
 {
@@ -62,24 +107,8 @@ ftpd_data_pasv(ftpd_session_t *sess)
         return -1;
     }
 
-    /* Try ports in the configured range */
-    for (port = sess->server->config.pasv_lo;
-         port <= sess->server->config.pasv_hi;
-         port++) {
-
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = 0;  /* bind to any address */
-        addr.sin_port = htons(port);
-
-        if (bind(sock, &addr, sizeof(addr)) == 0)
-            break;
-    }
-
-    if (port > sess->server->config.pasv_hi) {
-        ftpd_log(LOG_ERROR, "%s: no port available in range %d-%d",
-                 __func__, sess->server->config.pasv_lo,
-                 sess->server->config.pasv_hi);
+    port = bind_pasv_port(sess, sock);
+    if (port < 0) {
         closesocket(sock);
         return -1;
     }
@@ -125,7 +154,6 @@ ftpd_data_pasv(ftpd_session_t *sess)
 int
 ftpd_data_epsv(ftpd_session_t *sess)
 {
-    struct sockaddr_in addr;
     int sock;
     int port;
 
@@ -138,24 +166,8 @@ ftpd_data_epsv(ftpd_session_t *sess)
         return -1;
     }
 
-    /* Try ports in the configured range */
-    for (port = sess->server->config.pasv_lo;
-         port <= sess->server->config.pasv_hi;
-         port++) {
-
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = 0;  /* bind to any address */
-        addr.sin_port = htons(port);
-
-        if (bind(sock, &addr, sizeof(addr)) == 0)
-            break;
-    }
-
-    if (port > sess->server->config.pasv_hi) {
-        ftpd_log(LOG_ERROR, "%s: no port available in range %d-%d",
-                 __func__, sess->server->config.pasv_lo,
-                 sess->server->config.pasv_hi);
+    port = bind_pasv_port(sess, sock);
+    if (port < 0) {
         closesocket(sock);
         return -1;
     }


### PR DESCRIPTION
Beide passiven Pfade hatten `addr.sin_addr.s_addr = 0` fest verdrahtet, FTPD belegte einen passiven Port also auf **jeder** Adresse des Hosts. `PASVADR` baute nur die 227/229-Antwort und konnte den Bind nicht verschieben. Ein mitlaufender TLS-Terminator — der einzige Weg zu FTPS auf MVS 3.8j, siehe #59 — kann die öffentliche Adresse auf denselben Ports dann nicht binden, und FTPDs eigener `bind()` scheitert, sobald der Proxy zuerst da war: `PASV` antwortet `425`.

## Änderung

`PASVBIND` (Default `ANY` = heutiges Verhalten) ist die **Bind**-Adresse, `PASVADR` bleibt die **angekündigte**:

```
PASVBIND=127.0.0.1      FTPD hört auf Loopback
PASVADR=203,0,113,10    der Client wird zum Proxy geschickt
```

Damit sind lokal und öffentlich getrennt — wofür es `PASVADR` als eigenen Parameter überhaupt gibt.

Die in `ftpd_data_pasv()` und `ftpd_data_epsv()` wortgleich duplizierte Bind-Schleife ist jetzt ein Helper (`bind_pasv_port()`): die beiden Pfade können bei der Bind-Adresse nicht auseinanderlaufen, und die Meldung bei erschöpftem Portbereich nennt die Adresse, auf der es scheiterte. Das Parsing folgt dem Kontrollsocket (`src/ftpd.c:293`): `ANY` oder dotted quad, Kommaform wie bei `PASVADR`, alles andere warnt und bleibt `ANY`. `samplib/ftpdprm0` erklärt die Kombination.

## Verifikation

`make clean && make` sauber (`-Wall -Werror`). Zieltest folgt.

Closes #60

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk