### PR TITLE
Read every address parameter through one parser (#76)

### DIFF
--- a/doc/FTPD_CONCEPT.md
+++ b/doc/FTPD_CONCEPT.md
@@ -773,8 +773,9 @@ the program.
 
 # Network
 SRVPORT=21
-SRVIP=ANY
-PASVADR=127,0,0,1
+SRVBIND=ANY
+PASVADR=ANY
+PASVBIND=ANY
 PASVPORTS=22000-22200
 
 # Limits
@@ -805,6 +806,24 @@ DEFVOLUME=PUB001
 # PUB001,3390   PUBLIC DATASETS
 # SYSCPK,3350   COMPILER/TOOLS
 ```
+
+**Address parameters** — `SRVBIND`, `PASVBIND` and `PASVADR` are read by
+one parser (`ftpd_adr_parse()`, `src/ftpd#adr.c`). Each accepts `ANY`, a
+dotted quad (`127.0.0.1`) or the comma form (`127,0,0,1`); all four octets
+must be present and in range 0–255. A value that is not an address is
+refused with a message naming the default that takes its place — FTPD never
+silently binds or advertises something other than what was configured.
+
+| Key | Meaning | `ANY` means |
+|-----|---------|-------------|
+| `SRVBIND` | where the control listener binds (old spelling `SRVIP` is still read) | every address of the host (0.0.0.0) |
+| `PASVBIND` | where the passive data listener binds | every address of the host (0.0.0.0) |
+| `PASVADR` | what the client is told to connect to in the 227 reply | the address this client reached the control connection on |
+
+`PASVBIND` and `PASVADR` differ only behind a proxy or NAT: `PASVBIND`
+keeps FTPD on a private interface while `PASVADR` sends the client to the
+public one. `/F FTPD,D CONFIG` shows the effective values, including which
+spelling set `SRVBIND` and what `PASVADR=ANY` resolves to.
 
 ### 5.2 JCL Procedure
 

--- a/include/ftpd#adr.h
+++ b/include/ftpd#adr.h
@@ -1,0 +1,44 @@
+#ifndef FTPD_ADR_H
+#define FTPD_ADR_H
+/*
+** FTPD Address Parameter Parsing
+**
+** One parser for every address FTPD is configured with (SRVBIND, PASVBIND,
+** PASVADR).  They used to be read three different ways, with three different
+** ideas of what an unreadable value means -- see issue #76.
+**
+** Free of project and MVS headers on purpose: this is the one piece of the
+** configuration that a host unit test can link (test/tstadr.c).
+*/
+
+/* Buffer size for a stored address: "255.255.255.255" + NUL. */
+#define FTPD_ADR_SIZE   16
+
+/* ftpd_adr_parse() return codes */
+#define FTPD_ADR_BAD    (-1)        /* not an address FTPD understands   */
+#define FTPD_ADR_ANY    0           /* the literal ANY                   */
+#define FTPD_ADR_OK     1           /* a valid IPv4 address              */
+
+/*
+** Parse a configured address.
+**
+** Accepted: "ANY" in any case, or an IPv4 address written either dotted
+** (127.0.0.1) or comma separated (127,0,0,1) -- the comma form is what the
+** FTP protocol itself uses, and PARMLIB members have always been written
+** both ways.  All four octets must be present, in range 0-255, with nothing
+** trailing them.
+**
+** out   -- optional, FTPD_ADR_SIZE bytes.  Receives "ANY" or the address in
+**          dotted form.  Left untouched when the value is rejected, so a
+**          caller can keep its default simply by ignoring the return code
+**          (though every caller should say what default it fell back to).
+** addr  -- optional.  Receives the address in host byte order; 0 for ANY.
+**
+** Returns FTPD_ADR_ANY, FTPD_ADR_OK or FTPD_ADR_BAD.  ANY and BAD are
+** deliberately distinct: binding every address is a decision, not an error
+** recovery.
+*/
+int ftpd_adr_parse(const char *value, char *out, unsigned *addr)
+                                                            asm("FTPADRPA");
+
+#endif /* FTPD_ADR_H */

--- a/include/ftpd#cfg.h
+++ b/include/ftpd#cfg.h
@@ -4,6 +4,8 @@
 ** FTPD Configuration
 */
 
+#include "ftpd#adr.h"               /* address parameter parsing     */
+
 /* --- DASD volume entry --- */
 typedef struct ftpd_dasd {
     char            volser[7];      /* volume serial                 */
@@ -13,16 +15,33 @@ typedef struct ftpd_dasd {
 #define FTPD_MAX_DASD       32      /* max configured DASD volumes   */
 
 /* --- Server configuration --- */
+/*
+** The three address fields below are all written by ftpd_adr_parse(), so
+** they hold either the literal "ANY" or a validated dotted quad -- never a
+** value the socket layer would have to guess about.  What ANY means is per
+** field, see the comments.
+*/
 typedef struct ftpd_config {
     /* Network */
     int             port;           /* listen port (default 21)      */
-    char            bind_ip[16];    /* bind IP ("ANY" = 0.0.0.0)    */
-    char            pasv_addr[16];  /* PASV address for responses    */
-    char            pasv_bind[16];  /* passive listener bind address
-                                    ** ("ANY" = 0.0.0.0).  NOT the same
-                                    ** as pasv_addr: this is where FTPD
-                                    ** listens, that is what the client
-                                    ** is told to connect to           */
+    char            bind_ip[FTPD_ADR_SIZE];
+                                    /* control listener bind address,
+                                    ** SRVBIND (alias SRVIP).
+                                    ** "ANY" = 0.0.0.0                */
+    int             bind_ip_alias;  /* 1 = set through the old SRVIP
+                                    ** spelling; the CONFIG dump says so */
+    char            pasv_addr[FTPD_ADR_SIZE];
+                                    /* address the client is told to
+                                    ** connect to, PASVADR.  "ANY" =
+                                    ** take it from the control
+                                    ** connection, per session        */
+    char            pasv_bind[FTPD_ADR_SIZE];
+                                    /* passive listener bind address,
+                                    ** PASVBIND.  "ANY" = 0.0.0.0.
+                                    ** NOT the same as pasv_addr: this
+                                    ** is where FTPD listens, that is
+                                    ** what the client is told to
+                                    ** connect to                     */
     int             pasv_lo;        /* PASV port range low           */
     int             pasv_hi;        /* PASV port range high          */
     /* Limits */

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -24,6 +24,7 @@
 #include "racf.h"                   /* security environment         */
 #include "clibtry.h"                /* try(), tryrc() ESTAE recovery */
 
+#include "ftpd#adr.h"               /* address parameter parsing    */
 #include "ftpd#cfg.h"               /* configuration                */
 #include "ftpd#log.h"               /* logging & trace              */
 #include "ftpd#xlt.h"               /* EBCDIC/ASCII translation     */

--- a/project.toml
+++ b/project.toml
@@ -18,6 +18,15 @@ sources = ["src/ftpd*.c"]
 ac = 1                    # APF authorization (SETCODE AC(1));
 # ld370 supports --ac -- mbt wiring pending.
 
+# ── Tests ────────────────────────────────────────────────
+# ftpd_adr_parse() -- the shared SRVBIND/PASVBIND/PASVADR parser (#76).
+# ftpd#adr.c is free of ftpd.h and of MVS services, so this is DUAL: it runs
+# natively via test-host and on MVS via test-mvs.  The helper source is listed
+# explicitly for the host link (no autocall there).
+[[test]]
+name = "TSTADR"
+sources = ["test/tstadr.c", "src/ftpd#adr.c"]
+
 # ── Dependencies ─────────────────────────────────────────
 # Only ufsd remains a real dependency: libufs.h / libufs.a are ufsd-specific.
 # crent370 was dropped -- every crent370 header ftpd uses (clib*.h, racf.h,

--- a/samplib/ftpdprm0
+++ b/samplib/ftpdprm0
@@ -8,9 +8,19 @@
 # DASD volumes: VOLSER,UNIT (e.g. PUB001,3390)
 #
 # --- Network ---
+#
+# Every address below takes ANY, a dotted quad (127.0.0.1) or the comma
+# form (127,0,0,1); an unreadable value is refused with a message naming
+# the default it fell back to -- it never binds something else silently.
+#
 SRVPORT=2121
-SRVIP=ANY
-PASVADR=127,0,0,1
+#
+# SRVBIND is where the control listener binds.  ANY (the default) takes
+# every address of the host; name one to keep FTPD off the others, e.g.
+# when only a proxy is meant to reach it.  The old spelling SRVIP is
+# still read and means the same thing.
+SRVBIND=ANY
+#
 PASVPORTS=22000-22200
 #
 # PASVBIND is where the passive listener binds, PASVADR is what the
@@ -21,6 +31,13 @@ PASVPORTS=22000-22200
 #   PASVBIND=127.0.0.1     FTPD listens on loopback
 #   PASVADR=203,0,113,10   client is sent to the proxy
 PASVBIND=ANY
+#
+# PASVADR=ANY (the default) sends the client to the address it reached
+# the control connection on, which is right whenever FTPD is reachable
+# directly.  Set an address only when the client must connect somewhere
+# else than it is talking to -- a proxy, or NAT with a public address
+# the host itself does not carry.
+PASVADR=ANY
 #
 # --- Limits ---
 MAXSESSIONS=10
@@ -41,7 +58,7 @@ BANNER=MVS 3.8j FTPD Server
 #
 # Only turn this on when a terminating proxy is guaranteed in front of
 # FTPD and FTPD is not reachable directly -- bind it to the private
-# interface with SRVIP.  Run bare, it promises clients a confidentiality
+# interface with SRVBIND.  Run bare, it promises clients a confidentiality
 # it does not deliver.  AUTH TLS (explicit FTPS) stays 504 either way;
 # this is for implicit FTPS.
 #

--- a/src/ftpd#adr.c
+++ b/src/ftpd#adr.c
@@ -1,0 +1,96 @@
+/*
+** FTPD Address Parameter Parsing
+**
+** See include/ftpd#adr.h.  Hand-rolled rather than sscanf("%u.%u.%u.%u"):
+** sscanf reports four conversions for "1.2.3.4junk" and for "999.1.2.3" as
+** well, which is how an out-of-range or mistyped address used to reach the
+** socket layer unnoticed.  The loop below costs less code than the sscanf
+** call it replaces and rejects both.
+**
+** '0'-'9' are contiguous in EBCDIC as well as ASCII, so the digit test and
+** the '0' subtraction are encoding independent.
+*/
+#include <string.h>
+
+#include "ftpd#adr.h"
+
+/* --------------------------------------------------------------------
+** The literal ANY, in any case.  Spelled out instead of strcasecmp()
+** (not in the cc370 sysroot) or tolower() (would pull in ctype).
+** ----------------------------------------------------------------- */
+static int
+is_any(const char *s)
+{
+    return (s[0] == 'A' || s[0] == 'a') &&
+           (s[1] == 'N' || s[1] == 'n') &&
+           (s[2] == 'Y' || s[2] == 'y') &&
+            s[3] == '\0';
+}
+
+/* --------------------------------------------------------------------
+** Parse an address parameter.  See ftpd#adr.h for the contract.
+** ----------------------------------------------------------------- */
+int
+ftpd_adr_parse(const char *value, char *out, unsigned *addr)
+{
+    unsigned    octet[4];
+    const char *p;
+    int         i;
+    int         digits;
+    size_t      len;
+
+    if (!value)
+        return FTPD_ADR_BAD;
+
+    if (is_any(value)) {
+        if (out)
+            strcpy(out, "ANY");
+        if (addr)
+            *addr = 0;
+        return FTPD_ADR_ANY;
+    }
+
+    /* Reject before parsing what would not survive being stored: a value
+    ** longer than the buffer used to be truncated into a valid but
+    ** different address (192.168.100.2000 -> 192.168.100.200). */
+    len = strlen(value);
+    if (len == 0 || len >= FTPD_ADR_SIZE)
+        return FTPD_ADR_BAD;
+
+    p = value;
+    for (i = 0; i < 4; i++) {
+        unsigned v = 0;
+
+        for (digits = 0; *p >= '0' && *p <= '9'; digits++, p++) {
+            if (digits == 3)
+                return FTPD_ADR_BAD;
+            v = v * 10 + (unsigned)(*p - '0');
+        }
+        if (digits == 0 || v > 255)
+            return FTPD_ADR_BAD;
+
+        octet[i] = v;
+
+        if (i < 3) {
+            if (*p != '.' && *p != ',')
+                return FTPD_ADR_BAD;
+            p++;
+        }
+    }
+
+    /* Four octets parsed -- anything left is garbage, not an address. */
+    if (*p != '\0')
+        return FTPD_ADR_BAD;
+
+    if (out) {
+        for (i = 0; value[i]; i++)
+            out[i] = (value[i] == ',') ? '.' : value[i];
+        out[i] = '\0';
+    }
+
+    if (addr)
+        *addr = (octet[0] << 24) | (octet[1] << 16) |
+                (octet[2] <<  8) |  octet[3];
+
+    return FTPD_ADR_OK;
+}

--- a/src/ftpd#cfg.c
+++ b/src/ftpd#cfg.c
@@ -22,8 +22,11 @@ ftpdcfg_defaults(ftpd_config_t *cfg)
 
     /* Network */
     cfg->port = 2121;
-    strcpy(cfg->bind_ip, "ANY");
-    strcpy(cfg->pasv_addr, "127.0.0.1");
+    strcpy(cfg->bind_ip, "ANY");    /* listen on every address       */
+    cfg->bind_ip_alias = 0;
+    strcpy(cfg->pasv_addr, "ANY");  /* advertise the address the client
+                                    ** reached us on -- a literal default
+                                    ** cannot be right for every client */
     strcpy(cfg->pasv_bind, "ANY");  /* bind every address, as before */
     cfg->pasv_lo = 22000;
     cfg->pasv_hi = 22200;
@@ -138,44 +141,35 @@ parse_keyvalue(ftpd_config_t *cfg, const char *key, const char *value)
             cfg->port = 21;
         }
     }
-    else if (strcmp(key, "SRVIP") == 0) {
-        strncpy(cfg->bind_ip, value, sizeof(cfg->bind_ip) - 1);
+    else if (strcmp(key, "SRVBIND") == 0 || strcmp(key, "SRVIP") == 0) {
+        /* Where the control listener binds -- ANY or one address.  SRVIP is
+        ** the old spelling, still read so existing PARMLIB members keep
+        ** working; SRVBIND is what the dump and the sample call it. */
+        if (ftpd_adr_parse(value, cfg->bind_ip, NULL) == FTPD_ADR_BAD) {
+            ftpd_log(LOG_WARN, "%s: invalid %s %s, listening on every "
+                     "address (ANY)", __func__, key, value);
+            strcpy(cfg->bind_ip, "ANY");
+        }
+        cfg->bind_ip_alias = (strcmp(key, "SRVIP") == 0);
     }
     else if (strcmp(key, "PASVADR") == 0) {
-        /* Accept comma-separated: 127,0,0,1 -> 127.0.0.1 */
-        char buf[16];
-        int i;
-        strncpy(buf, value, sizeof(buf) - 1);
-        buf[sizeof(buf) - 1] = '\0';
-        for (i = 0; buf[i]; i++) {
-            if (buf[i] == ',')
-                buf[i] = '.';
+        /* What the client is told to connect to.  ANY -- and anything
+        ** unreadable -- means the address the client reached us on, which
+        ** the session resolves from the control connection. */
+        if (ftpd_adr_parse(value, cfg->pasv_addr, NULL) == FTPD_ADR_BAD) {
+            ftpd_log(LOG_WARN, "%s: invalid PASVADR %s, using the control "
+                     "connection address", __func__, value);
+            strcpy(cfg->pasv_addr, "ANY");
         }
-        strcpy(cfg->pasv_addr, buf);
     }
     else if (strcmp(key, "PASVBIND") == 0) {
         /* Where the passive listener binds -- ANY or one address.  A
         ** co-located TLS proxy owns the public address on the same
         ** ports, so FTPD must be able to stay off it. */
-        char buf[16];
-        int i;
-        strncpy(buf, value, sizeof(buf) - 1);
-        buf[sizeof(buf) - 1] = '\0';
-        for (i = 0; buf[i]; i++) {
-            if (buf[i] == ',')
-                buf[i] = '.';
-        }
-        if (strcmp(buf, "ANY") == 0 || strcmp(buf, "any") == 0) {
+        if (ftpd_adr_parse(value, cfg->pasv_bind, NULL) == FTPD_ADR_BAD) {
+            ftpd_log(LOG_WARN, "%s: invalid PASVBIND %s, binding every "
+                     "address (ANY)", __func__, value);
             strcpy(cfg->pasv_bind, "ANY");
-        } else {
-            unsigned b1, b2, b3, b4;
-            if (sscanf(buf, "%u.%u.%u.%u", &b1, &b2, &b3, &b4) == 4) {
-                strcpy(cfg->pasv_bind, buf);
-            } else {
-                ftpd_log(LOG_WARN, "%s: invalid PASVBIND %s, using ANY",
-                         __func__, value);
-                strcpy(cfg->pasv_bind, "ANY");
-            }
         }
     }
     else if (strcmp(key, "PASVPORTS") == 0) {
@@ -329,9 +323,16 @@ ftpdcfg_dump(const ftpd_config_t *cfg)
     int i;
 
     ftpd_log_wto("FTPD040I Configuration:");
-    ftpd_log_wto("FTPD041I   SRVPORT=%d SRVIP=%s", cfg->port, cfg->bind_ip);
+    ftpd_log_wto("FTPD041I   SRVPORT=%d SRVBIND=%s%s", cfg->port,
+                 cfg->bind_ip,
+                 cfg->bind_ip_alias ? " (set as SRVIP)" : "");
+    /* PASVADR=ANY is not an address the client could use -- say what it
+    ** resolves to instead, the operator is reading this to find out why a
+    ** client connects where it does. */
     ftpd_log_wto("FTPD042I   PASVADR=%s PASVPORTS=%d-%d PASVBIND=%s",
-                 cfg->pasv_addr, cfg->pasv_lo, cfg->pasv_hi,
+                 strcmp(cfg->pasv_addr, "ANY") == 0
+                     ? "ANY (control connection)" : cfg->pasv_addr,
+                 cfg->pasv_lo, cfg->pasv_hi,
                  cfg->pasv_bind);
     ftpd_log_wto("FTPD043I   MAXSESSIONS=%d IDLETIMEOUT=%d",
                  cfg->max_sessions, cfg->idle_timeout);

--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -134,7 +134,18 @@ ftpd_data_pasv(ftpd_session_t *sess)
     pasv_addr = sess->server->config.pasv_addr;
     if (ftpd_adr_parse(pasv_addr, NULL, &advaddr) != FTPD_ADR_OK) {
         len = sizeof(addr);
-        getsockname(sess->ctrl_sock, (struct sockaddr *)&addr, &len);
+        /* This is the default path now, not a rare fallback: without the rc
+        ** check a failed getsockname() would put whatever addr happens to
+        ** hold into the 227 reply and send the client there. */
+        if (getsockname(sess->ctrl_sock, (struct sockaddr *)&addr, &len)
+                != 0) {
+            ftpd_log(LOG_ERROR, "%s: getsockname() failed, errno=%d",
+                     __func__, errno);
+            closesocket(sess->pasv_sock);
+            sess->pasv_sock = -1;
+            sess->data_mode = DATA_NONE;
+            return -1;
+        }
         advaddr = ntohl(addr.sin_addr.s_addr);
     }
 

--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -58,15 +58,19 @@ static int
 bind_pasv_port(ftpd_session_t *sess, int sock)
 {
     struct sockaddr_in addr;
-    unsigned bindaddr = 0;          /* INADDR_ANY */
+    unsigned bindaddr;
     const char *pb = sess->server->config.pasv_bind;
-    unsigned b1, b2, b3, b4;
     int port;
 
-    if (pb[0] && strcmp(pb, "ANY") != 0 &&
-        sscanf(pb, "%u.%u.%u.%u", &b1, &b2, &b3, &b4) == 4) {
-        bindaddr = htonl((b1 << 24) | (b2 << 16) | (b3 << 8) | b4);
+    /* ANY gives 0 = INADDR_ANY.  A value the parser rejects means the
+    ** operator asked for an address FTPD cannot bind -- refuse the passive
+    ** listener instead of quietly taking every address (issue #76).  The
+    ** config parser already validated this, so it is a last line only. */
+    if (ftpd_adr_parse(pb, NULL, &bindaddr) == FTPD_ADR_BAD) {
+        ftpd_log(LOG_ERROR, "%s: PASVBIND %s is not an address", __func__, pb);
+        return -1;
     }
+    bindaddr = htonl(bindaddr);
 
     for (port = sess->server->config.pasv_lo;
          port <= sess->server->config.pasv_hi;
@@ -94,6 +98,7 @@ ftpd_data_pasv(ftpd_session_t *sess)
     int sock;
     int port;
     int len;
+    unsigned advaddr;
     unsigned a1, a2, a3, a4;
     int p1, p2;
     const char *pasv_addr;
@@ -122,17 +127,21 @@ ftpd_data_pasv(ftpd_session_t *sess)
     sess->pasv_sock = sock;
     sess->data_mode = DATA_PASV;
 
-    /* Parse PASV address for response */
+    /* The address the client is told to connect to.  PASVADR=ANY (the
+    ** default) means "wherever this client reached us", which is the local
+    ** end of the control connection -- right for a directly reachable
+    ** server, wrong behind a proxy, which is why PASVADR exists at all. */
     pasv_addr = sess->server->config.pasv_addr;
-    if (sscanf(pasv_addr, "%u.%u.%u.%u", &a1, &a2, &a3, &a4) != 4) {
-        /* Fallback: get address from control socket */
+    if (ftpd_adr_parse(pasv_addr, NULL, &advaddr) != FTPD_ADR_OK) {
         len = sizeof(addr);
         getsockname(sess->ctrl_sock, (struct sockaddr *)&addr, &len);
-        a1 = (ntohl(addr.sin_addr.s_addr) >> 24) & 0xFF;
-        a2 = (ntohl(addr.sin_addr.s_addr) >> 16) & 0xFF;
-        a3 = (ntohl(addr.sin_addr.s_addr) >> 8) & 0xFF;
-        a4 = ntohl(addr.sin_addr.s_addr) & 0xFF;
+        advaddr = ntohl(addr.sin_addr.s_addr);
     }
+
+    a1 = (advaddr >> 24) & 0xFF;
+    a2 = (advaddr >> 16) & 0xFF;
+    a3 = (advaddr >>  8) & 0xFF;
+    a4 =  advaddr        & 0xFF;
 
     p1 = (port >> 8) & 0xFF;
     p2 = port & 0xFF;

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -270,7 +270,7 @@ socket_thread(void *arg1, void *arg2)
     int len;
     int sock;
     int rc;
-    unsigned a1, a2, a3, a4;
+    unsigned bindaddr;
     ftpd_session_t *sess;
 
     (void)arg2;
@@ -290,15 +290,19 @@ socket_thread(void *arg1, void *arg2)
     saddr.sin_family = AF_INET;
     saddr.sin_port = htons(server->config.port);
 
-    if (strcmp(server->config.bind_ip, "ANY") == 0) {
-        saddr.sin_addr.s_addr = 0;
-    } else {
-        if (sscanf(server->config.bind_ip, "%u.%u.%u.%u",
-                   &a1, &a2, &a3, &a4) == 4) {
-            saddr.sin_addr.s_addr = htonl(
-                (a1 << 24) | (a2 << 16) | (a3 << 8) | a4);
-        }
+    /* The config parser only stores ANY or a validated address, so this
+    ** cannot normally fail -- and if it ever does, refuse to listen rather
+    ** than fall through to the 0 left by the memset.  Binding every address
+    ** because one could not be read is the opposite of what was asked for
+    ** (issue #76). */
+    if (ftpd_adr_parse(server->config.bind_ip, NULL, &bindaddr)
+            == FTPD_ADR_BAD) {
+        ftpd_log_wto("FTPD055E SRVBIND %s is not an address, not listening",
+                     server->config.bind_ip);
+        closesocket(sock);
+        return 8;
     }
+    saddr.sin_addr.s_addr = htonl(bindaddr);
 
     /* Close any stale socket left over from a previous instance that
     ** did not shut down cleanly.  On MVS the socket fd table is
@@ -329,8 +333,8 @@ socket_thread(void *arg1, void *arg2)
 
     if (bind(sock, &saddr, sizeof(saddr)) < 0) {
         int err = errno;
-        ftpd_log_wto("FTPD051E bind() failed on port %d, errno=%d",
-                     server->config.port, err);
+        ftpd_log_wto("FTPD051E bind() failed on %s port %d, errno=%d",
+                     server->config.bind_ip, server->config.port, err);
         if (err == EADDRINUSE) {
             ftpd_log_wto("FTPD051I EADDRINUSE, retrying in 10s");
             __asm__("STIMER WAIT,BINTVL==F'1000'");
@@ -353,8 +357,11 @@ socket_thread(void *arg1, void *arg2)
     }
 
     server->listen_sock = sock;
-    ftpd_log_wto("FTPD054I Listening for FTP connections on port %d",
-                 server->config.port);
+    /* Name the address, not just the port: ANY and one interface look the
+    ** same from the console otherwise, and that is exactly the difference
+    ** an operator who set SRVBIND wants confirmed (issue #76). */
+    ftpd_log_wto("FTPD054I Listening for FTP connections on %s port %d",
+                 server->config.bind_ip, server->config.port);
 
     /* Accept loop — non-blocking socket + ecb_timed_wait.
     **

--- a/test/tstadr.c
+++ b/test/tstadr.c
@@ -1,0 +1,125 @@
+/* TSTADR.C
+** Tests for ftpd_adr_parse() -- the shared parser behind SRVBIND (SRVIP),
+** PASVBIND and PASVADR (issue #76).
+**
+** The regression that started it: SRVIP=127,0,0,1 was copied into the config
+** unchanged, sscanf("%u.%u.%u.%u") then reported one conversion instead of
+** four, and the bind silently kept INADDR_ANY -- FTPD listened on every
+** address of the host while the operator had asked for one.  The cases below
+** pin the comma form down, plus everything else that used to pass for an
+** address: truncated values, trailing garbage, octets over 255.
+**
+** ftpd#adr.c is free of project and MVS headers, so this is a DUAL test: it
+** runs natively via `make test-host` and on MVS via `make test-mvs`.
+*/
+#include <stdio.h>
+#include <string.h>
+
+#include "ftpd#adr.h"
+#include <mbtcheck.h>
+
+/* An address in host byte order, for the expected values below. */
+#define QUAD(a, b, c, d) \
+    (((unsigned)(a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
+/* Parse and report whether value, out and addr all came out as expected. */
+static int
+ok(const char *value, const char *want_out, unsigned want_addr)
+{
+    char     out[FTPD_ADR_SIZE];
+    unsigned addr = 0xDEADBEEF;
+
+    memset(out, '\0', sizeof(out));
+
+    if (ftpd_adr_parse(value, out, &addr) != FTPD_ADR_OK)
+        return 0;
+
+    return strcmp(out, want_out) == 0 && addr == want_addr;
+}
+
+/* Rejected values must leave the caller's buffer and address alone, so a
+** default set before the call survives. */
+static int
+bad(const char *value)
+{
+    char     out[FTPD_ADR_SIZE];
+    unsigned addr = 0xDEADBEEF;
+
+    strcpy(out, "ANY");
+
+    if (ftpd_adr_parse(value, out, &addr) != FTPD_ADR_BAD)
+        return 0;
+
+    return strcmp(out, "ANY") == 0 && addr == 0xDEADBEEF;
+}
+
+int
+main(void)
+{
+    char     out[FTPD_ADR_SIZE];
+    unsigned addr = 0xDEADBEEF;
+
+    printf("=== FTPD address parameter tests (#76) ===\n");
+
+    /* --- the reported bug: comma form on a bind address --------------- */
+    CHECK(ok("127,0,0,1", "127.0.0.1", QUAD(127, 0, 0, 1)),
+          "comma form 127,0,0,1 parses (was silently ANY)");
+    CHECK(ok("123,0,0,1", "123.0.0.1", QUAD(123, 0, 0, 1)),
+          "comma form is normalised to dotted form for the config dump");
+
+    /* --- dotted form, the boundaries ---------------------------------- */
+    CHECK(ok("127.0.0.1", "127.0.0.1", QUAD(127, 0, 0, 1)),
+          "dotted form 127.0.0.1 parses");
+    CHECK(ok("0.0.0.0", "0.0.0.0", 0u), "0.0.0.0 parses (explicit, not ANY)");
+    CHECK(ok("255.255.255.255", "255.255.255.255", 0xFFFFFFFFu),
+          "255.255.255.255 parses -- longest value still fits the buffer");
+    CHECK(ok("203.0.113.10", "203.0.113.10", QUAD(203, 0, 113, 10)),
+          "a public address parses");
+    CHECK(ok("10,1,2,3", "10.1.2.3", QUAD(10, 1, 2, 3)),
+          "short octets in comma form parse");
+
+    /* --- ANY is a decision, not an error ------------------------------ */
+    memset(out, '\0', sizeof(out));
+    CHECK(ftpd_adr_parse("ANY", out, &addr) == FTPD_ADR_ANY &&
+          strcmp(out, "ANY") == 0 && addr == 0,
+          "ANY reports FTPD_ADR_ANY and address 0");
+    memset(out, '\0', sizeof(out));
+    CHECK(ftpd_adr_parse("any", out, &addr) == FTPD_ADR_ANY &&
+          strcmp(out, "ANY") == 0,
+          "any is case-insensitive and stored uppercase");
+    CHECK(ftpd_adr_parse("Any", NULL, NULL) == FTPD_ADR_ANY,
+          "Any parses with both outputs omitted");
+
+    /* --- what used to pass unnoticed ---------------------------------- */
+    CHECK(bad("127.0.0"), "three octets are rejected (was silently ANY)");
+    CHECK(bad("127.0.0.1.5"), "five octets are rejected");
+    CHECK(bad("localhost"), "a hostname is rejected -- FTPD resolves nothing");
+    CHECK(bad("1.2.3.4junk"), "trailing garbage is rejected (sscanf took it)");
+    CHECK(bad("999.1.2.3"), "an octet over 255 is rejected (sscanf took it)");
+    CHECK(bad("256.0.0.1"), "256 is rejected -- one past the boundary");
+    CHECK(bad("192.168.100.2000"),
+          "an over-long value is rejected, not truncated to a valid address");
+    CHECK(bad("1.2.3."), "a missing last octet is rejected");
+    CHECK(bad(".1.2.3"), "a missing first octet is rejected");
+    CHECK(bad("1..2.3"), "an empty octet is rejected");
+    CHECK(bad(""), "an empty value is rejected");
+    CHECK(bad(" 127.0.0.1"), "a leading blank is rejected (the config trims)");
+    CHECK(bad("127.0.0.1 "), "a trailing blank is rejected (the config trims)");
+    CHECK(bad("1.2.3.-4"), "a negative octet is rejected");
+    CHECK(bad("0000.0.0.1"), "more than three digits in an octet are rejected");
+    CHECK(bad("ANYTHING"), "ANY must stand alone");
+    CHECK(ftpd_adr_parse(NULL, NULL, NULL) == FTPD_ADR_BAD,
+          "a NULL value is rejected");
+
+    /* --- the config keeps the string, the socket layer the binary ----- */
+    memset(out, '\0', sizeof(out));
+    CHECK(ftpd_adr_parse("10,20,30,40", out, NULL) == FTPD_ADR_OK &&
+          strcmp(out, "10.20.30.40") == 0,
+          "the address alone can be requested");
+    addr = 0;
+    CHECK(ftpd_adr_parse("10.20.30.40", NULL, &addr) == FTPD_ADR_OK &&
+          addr == QUAD(10, 20, 30, 40),
+          "the binary alone can be requested");
+
+    return mbt_test_summary("TSTADR");
+}


### PR DESCRIPTION
Closes #76

## Was war

`SRVIP`, `PASVADR` und `PASVBIND` wurden auf drei Arten gelesen, mit drei
Vorstellungen davon, was ein unlesbarer Wert bedeutet. `SRVIP` war die
schlechteste: der Wert wurde unverändert kopiert, die Kommaform, die die
beiden anderen akzeptieren, ließ `sscanf("%u.%u.%u.%u")` eine statt vier
Konversionen melden, der `else`-Zweig tat nichts, und `s_addr` behielt die 0
aus dem `memset`. `SRVIP=127,0,0,1` band jedes Interface des Hosts, ohne ein
Wort — genau das Gegenteil dessen, was der Operator wollte, und genau der
Aufbau, den das Sample für den Betrieb hinter einem TLS-Proxy (#59)
empfiehlt. Ein Tippfehler (`SRVIP=127.0.0`, `SRVIP=localhost`) war ebenso
still.

## Was jetzt

`ftpd_adr_parse()` (`src/ftpd#adr.c`) liest alle drei: `ANY`, dotted quad
oder Kommaform, vier Oktette, 0-255, nichts dahinter. Nebenbei schließt das
die Löcher, die die `sscanf`-Variante auch für `PASVBIND` offen ließ:
`999.1.2.3` und `1.2.3.4junk` galten als vier Konversionen, und ein zu
langer Wert wurde in eine gültige *andere* Adresse abgeschnitten
(`192.168.100.2000` -> `192.168.100.200`). Ein abgelehnter Wert wird mit
einer Meldung abgewiesen, die den einspringenden Default benennt; der
Listener startet lieber nicht, als auf `INADDR_ANY` durchzufallen.

- **`SRVBIND`** ist der neue kanonische Name. `SRVIP` wird weiter gelesen,
  und der CONFIG-Dump schreibt `(set as SRVIP)` dazu, wenn die alte
  Schreibweise gegriffen hat.
- **`PASVADR`** behält seinen Namen. Es ist die *annoncierte* Adresse, kein
  Bind — die Vereinheitlichung der Schreibweise mit den beiden Bind-Keys
  würde diesen echten Unterschied verwischen.
- **`PASVADR=ANY`** ist der neue Default (statt des literalen `127.0.0.1`,
  das nur für einen lokalen Client je richtig sein konnte) und heißt: die
  Adresse, über die dieser Client die Kontrollverbindung erreicht hat. Damit
  ist der bisher stille `getsockname()`-Fallback der benannte Default statt
  einer dritten Fehlerbehandlung — sichtbar im CONFIG-Dump.
- `FTPD054I` und `FTPD051E` nennen die Adresse, nicht nur den Port.
- Der `getsockname()`-RC wird geprüft (zweiter Commit): der Aufruf liegt ab
  jetzt auf jedem PASV einer Standardkonfiguration, nicht mehr nur im
  Fehlerfall. Schlägt er fehl, antwortet PASV 425, statt den Client an den
  Inhalt eines uninitialisierten `sockaddr` zu schicken.

## Test

`test/tstadr.c`, 29 Assertions, dual (host + MVS) — `ftpd#adr.c` ist frei
von `ftpd.h` und MVS-Services. Gegen die ersetzte Parserlogik fallen davon
10 um (plus ein Segfault bei `NULL`); mit dem neuen Parser sind
`make test-host` und der Cross-Build grün.

`make test-mvs` wurde nicht gefahren — das Modul ist gebaut, nicht auf MVS
ausgeführt. Getestet ist `ftpd_adr_parse()` selbst; das Routing in
`parse_keyvalue()` deckt kein Test ab.

## Vor dem Deploy zu erledigen

Ein PARMLIB-Member, dessen `SRVIP` bisher ignoriert wurde, wird mit diesem
Stand wirksam. Auf dem Testsystem steht in `SYS1.PARMLIB(FTPDPRM0)`
`SRVIP=123,0,0,1` — das parst jetzt sauber, FTPD bindet 123.0.0.1, die der
Stack nicht hat, meldet `FTPD051E bind() failed on 123.0.0.1 port 2121` und
hört **nicht** zu. Das Member muss im selben Wartungsfenster mit umgestellt
werden (`SRVBIND=ANY` oder die tatsächliche Adresse).

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk
