### PR TITLE
Restore a constant identity after every ACEE switch (#64)

### DIFF
--- a/include/ftpd#aut.h
+++ b/include/ftpd#aut.h
@@ -19,4 +19,23 @@
 int ftpd_auth_pass(ftpd_session_t *sess, const char *password)
                                                     asm("FTPAUTPS");
 
+/*
+** Identity switch around MVS services that must authorize against the
+** logged-in user (dataset OPEN, SVC 99, IDCAMS, JES internal reader).
+**
+** racf_set_acee() writes ASXBSENV, which is ADDRESS-SPACE-wide, while FTPD
+** runs one TCB per session.  Enter sets the session's ACEE; leave restores
+** the STC identity captured at startup — never the value observed on entry.
+** Restoring an observed value lets a worker inherit a concurrent session's
+** ACEE and leave it in ASXBSENV after both sides "restored" (#64); the AS
+** then rests on a user ACEE, and that user's racf_logout() clears ASXBSENV
+** to zero — which RAKF treats as "access permitted" (ICHSFR00: no ACEE ->
+** RACHGOOD).  Restoring a constant makes both states unreachable.
+**
+** Both are no-ops for an unauthenticated session (sess->acee == NULL), and
+** must be used in matched pairs around the shortest possible window.
+*/
+void ftpd_acee_enter(ftpd_session_t *sess)          asm("FTPACEEN");
+void ftpd_acee_leave(ftpd_session_t *sess)          asm("FTPACELV");
+
 #endif /* FTPD_AUT_H */

--- a/src/ftpd#aut.c
+++ b/src/ftpd#aut.c
@@ -110,3 +110,29 @@ ftpd_auth_pass(ftpd_session_t *sess, const char *password)
 
     return 0;
 }
+
+/* --------------------------------------------------------------------
+** Switch the address space to this session's security environment.
+**
+** No-op for an unauthenticated session.  See ftpd#aut.h for why leave()
+** restores a constant instead of the value observed here (#64).
+** ----------------------------------------------------------------- */
+void
+ftpd_acee_enter(ftpd_session_t *sess)
+{
+    if (sess->acee)
+        racf_set_acee(sess->acee);
+}
+
+/* --------------------------------------------------------------------
+** Restore the STC identity captured at startup (ftpd.c: server->stc_acee).
+**
+** stc_acee may be NULL if the startup RACINIT failed — that is still the
+** correct value to restore, and is the same value ABEND recovery writes.
+** ----------------------------------------------------------------- */
+void
+ftpd_acee_leave(ftpd_session_t *sess)
+{
+    if (sess->acee)
+        racf_set_acee(sess->server->stc_acee);
+}

--- a/src/ftpd#jes.c
+++ b/src/ftpd#jes.c
@@ -15,6 +15,7 @@
 */
 #include "ftpd.h"
 #include "ftpd#ses.h"
+#include "ftpd#aut.h"
 #include "ftpd#dat.h"
 #include "ftpd#jes.h"
 #include "ftpd#xlt.h"
@@ -149,11 +150,9 @@ ftpd_jes_submit(ftpd_session_t *sess)
     }
 
     /* Open JES2 internal reader under user's security environment */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        rc = jesiropn(&intrdr);
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    rc = jesiropn(&intrdr);
+    ftpd_acee_leave(sess);
     if (rc < 0) {
         ftpd_log(LOG_ERROR, "JES: jesiropn() failed rc=%d", rc);
         ftpd_data_close(sess);

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -9,6 +9,7 @@
 */
 #include "ftpd.h"
 #include "ftpd#ses.h"
+#include "ftpd#aut.h"
 #include "ftpd#dat.h"
 #include "ftpd#mvs.h"
 #include "ftpd#xlt.h"
@@ -851,11 +852,9 @@ ftpd_mvs_list(ftpd_session_t *sess, const char *arg, int nlst)
 
         /* Open the PDS directory under the user's security environment,
         ** so the RAKF authorization check evaluates against the user. */
-        {
-            ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-            pds = __listpd(prefix, filter);
-            if (sess->acee) racf_set_acee(oldacee);
-        }
+        ftpd_acee_enter(sess);
+        pds = __listpd(prefix, filter);
+        ftpd_acee_leave(sess);
         if (!pds || !pds[0]) {
             if (pds) __freepd(&pds);
             ftpd_session_reply(sess, FTP_550,
@@ -1145,11 +1144,9 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
         return 0;
 
     /* Switch to user's security environment for fopen */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        fp = fopen(fname, "rb");
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    fp = fopen(fname, "rb");
+    ftpd_acee_leave(sess);
     if (fp == NULL) {
         ftpd_log(LOG_INFO, "RETR: fopen('%s') failed", fname);
         if (member[0])
@@ -1612,13 +1609,11 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
         ** The window is a few instructions (two SVC 99 calls) and is not
         ** instrumented; total_recover in the operator log makes any such
         ** accumulation observable. */
-        {
-            ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-            rc = __dsalcf(ddname, "%s", opts);
-            if (rc == 0)
-                __dsfree(ddname);   /* release DD — fopen will re-allocate */
-            if (sess->acee) racf_set_acee(oldacee);   /* restore STC identity */
-        }
+        ftpd_acee_enter(sess);
+        rc = __dsalcf(ddname, "%s", opts);
+        if (rc == 0)
+            __dsfree(ddname);   /* release DD — fopen will re-allocate */
+        ftpd_acee_leave(sess);
 
         if (rc != 0) {
             ftpd_log(LOG_ERROR, "STOR: __dsalcf failed rc=%d", rc);
@@ -1639,11 +1634,9 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
     ftpd_log(LOG_INFO, "STOR: fopen('%s', 'wb') new=%d", fname, allocated_new);
 
     /* Switch to user's security environment for fopen */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        fp = fopen(fname, "wb");
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    fp = fopen(fname, "wb");
+    ftpd_acee_leave(sess);
     if (fp == NULL) {
         ftpd_session_reply(sess, FTP_550,
             "Cannot open dataset %s for writing", dsn);
@@ -1916,11 +1909,9 @@ ftpd_mvs_dele(ftpd_session_t *sess, const char *arg)
     }
 
     /* Switch to user's security environment for IDCAMS */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        rc = idcams(cmd);
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    rc = idcams(cmd);
+    ftpd_acee_leave(sess);
     if (rc != 0) {
         ftpd_session_reply(sess, FTP_550,
             "DELE fails: %s could not be deleted.", dsn);
@@ -1972,11 +1963,9 @@ ftpd_mvs_mkd(ftpd_session_t *sess, const char *arg)
     }
 
     /* Allocate new PDS under user's security environment */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        rc = alloc_new_dataset(sess, dsn, 1, ddname);
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    rc = alloc_new_dataset(sess, dsn, 1, ddname);
+    ftpd_acee_leave(sess);
     if (rc != 0) {
         ftpd_session_reply(sess, FTP_550,
             "Cannot create %s", dsn);
@@ -2029,11 +2018,9 @@ ftpd_mvs_rmd(ftpd_session_t *sess, const char *arg)
     snprintf(cmd, sizeof(cmd), " DELETE '%s'", dsn);
 
     /* Switch to user's security environment for IDCAMS */
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        rc = idcams(cmd);
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    rc = idcams(cmd);
+    ftpd_acee_leave(sess);
     if (rc != 0) {
         ftpd_session_reply(sess, FTP_550,
             "Cannot remove %s", dsn);
@@ -2125,15 +2112,24 @@ ftpd_mvs_rnto(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Authorize the TARGET name too.  RNFR already checked ALTER on the
+    ** source; without this the new name is only ever checked by IDCAMS
+    ** itself, i.e. by the RAKF check that runs under the address-space-wide
+    ** ASXBSENV — the one identity FTPD cannot guarantee is its own while
+    ** other sessions run (#64).  A denial clears the pending RNFR, like
+    ** every other failure path here. */
+    if (check_dataset_access(sess, dsn, RACF_ATTR_ALTER) != 0) {
+        sess->rnfr_path[0] = '\0';
+        return 0;
+    }
+
     /* Rename via IDCAMS ALTER under user's security environment */
     snprintf(cmd, sizeof(cmd),
              " ALTER '%s' NEWNAME('%s')", sess->rnfr_path, dsn);
 
-    {
-        ACEE *oldacee = sess->acee ? racf_set_acee(sess->acee) : NULL;
-        rc = idcams(cmd);
-        if (sess->acee) racf_set_acee(oldacee);
-    }
+    ftpd_acee_enter(sess);
+    rc = idcams(cmd);
+    ftpd_acee_leave(sess);
     if (rc != 0) {
         ftpd_session_reply(sess, FTP_550,
             "Rename of %s to %s failed.", sess->rnfr_path, dsn);


### PR DESCRIPTION
Closes part of #64 (stage 1 of 3 — see "Scope" below).

## Problem

`racf_set_acee()` writes **ASXBSENV**, which is address-space-wide, while FTPD
runs **one TCB per session**. The switch idiom saved the value *observed* on
entry and restored it on exit, so two workers interleave:

```
T1: old1 = ASXBSENV (=STC);  ASXBSENV = A
T2: old2 = ASXBSENV (=A!);   ASXBSENV = B      <- T2 inherits A
T1: ASXBSENV = old1 (=STC)
T2: ASXBSENV = old2 (=A)                       <- AS rests on a user ACEE
```

Two consequences, both persistent rather than transient:

1. The address space keeps running under a session's ACEE after both sides
   "restored" — including the listener and any path that does not switch.
2. When that session ends, `racf_logout()` finds its own ACEE in ASXBSENV and
   **clears the field to zero** (`libc370/src/racf/raclgout.c`). RAKF treats
   "no ACEE" as *access permitted*: `ICHSFR00` resolves RACHECK's ACEE from the
   plist, else ASXBSENV, and branches `BZ RACHGOOD` when that is zero. From
   then on the address space passes RAKF checks it should fail.

Reachability does not depend on a multi-CP configuration, as #64 assumed: every
one of these windows *waits* — dynalloc ENQ, VTOC I/O, and for DELE/RMD/RNTO an
entire IDCAMS program load — and a waiting TCB is exactly what lets a sibling
dispatch inside the window.

## Change

* `ftpd_acee_enter()` / `ftpd_acee_leave()` (`ftpd#aut.c`) replace the inline
  save/restore at all 9 sites (`ftpd#mvs.c` ×8, `ftpd#jes.c` ×1). `leave()`
  always restores `server->stc_acee` — the same constant the ABEND recovery
  path already writes (`ftpd#ses.c:285`). The resting value of ASXBSENV is now
  either the STC identity or a session's own ACEE during its own window; it can
  no longer be a foreign ACEE, and can no longer be zeroed by a logout.
* RNTO authorizes the **target** name (ALTER). RNFR checks only the source, so
  the new name was previously left to the RACHECK inside IDCAMS — i.e. to
  exactly the identity this bug corrupts.
* No behaviour change for an unauthenticated session (`sess->acee == NULL`):
  both helpers are no-ops, as before.

## Scope

This does **not** close the transient window — a worker can still observe
another session's identity *while* that session is inside its window. With the
pre-checks in place (`check_dataset_access` on every data path) that costs a
spurious denial (S913 → recovery), not entitlement. Removing it needs either
serialization or a per-task identity anchor; tracked as a separate issue.

Two follow-ups filed elsewhere:

* **libc370** — `racf_auth()` pokes ASXBSENV under an AS-wide ENQ although the
  RACHECK plist already has an ACEE field (`racheck.h`, offset `0x18`) that
  RAKF honours. Passing it directly makes the pre-check race-free by
  construction and drops the ENQ.
* **RAKF** — MVS 3.8j has no per-task ACEE anchor at all (`SYS1.AMODGEN(IKJTCB)`
  has no `TCBSENV`; the field only exists in later TCB levels), so a
  multi-TCB server has no correct way to give each task its own identity.

## Verification

Builds clean with `-Wall -Werror`. The race itself has no automated
reproduction under mbt: it needs two concurrent TCBs inside an APF-authorized
address space, and test modules are neither AC(1) nor APF-authorized, so
`racf_set_acee()`'s `MODESET` would S047 there.

Verified by inspection only so far. Outstanding before this is trusted in the
field: a functional check on the target with parallel sessions doing
LIST/RETR/STOR/DELE/RNTO, confirming no spurious 550s and no S913.

