### PR TITLE
Point the recovery comments at the caller that still holds the ASXB ENQ (#81)

### DIFF
--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -277,27 +277,38 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
     **
     ** ORDER IS LOAD-BEARING: this set_acee(STC) MUST precede the
     ** unlock(asxb) in step 2.  If the lock were released first, a worker
-    ** waiting in racf_auth() would acquire it and capture THIS session's
+    ** parked in racf_logout() would acquire it and capture THIS session's
     ** user ACEE (still in ASXBSENV) as its own oldacee, then restore that
     ** ACEE on exit — leaving ASXBSENV dangling once this session ends and
     ** racf_logout() frees it.  That is precisely the dangling-ACEE hazard
-    ** this reset exists to remove.  Do not reorder. */
+    ** this reset exists to remove.  Do not reorder.
+    **
+    ** (Until libc370 #58 the same capture could come from racf_auth();
+    ** that one now passes the ACEE in the RACHECK plist and touches
+    ** neither ASXBSENV nor the lock.  racf_logout() still does both —
+    ** libc370/src/racf/raclgout.c:18,23,73 — so the hazard survives it.) */
     racf_set_acee(sess->server->stc_acee);
 
-    /* 2. Release the ASXB ENQ if this task ABENDed inside racf_auth()'s
-    ** lock(asxb)/unlock(asxb) critical section.  MVS DEQs a task's ENQs
-    ** at task termination, but recovery keeps the task alive, so an
-    ** orphaned AS-wide ENQ would stall every session's racf_auth() until
-    ** this worker's next command.
+    /* 2. Release the ASXB ENQ if this task ABENDed while holding it.  MVS
+    ** DEQs a task's ENQs at task termination, but recovery keeps the task
+    ** alive, so an orphaned AS-wide ENQ would stall every other session's
+    ** login and teardown until this worker's next command.
     **
-    ** This is ownership-safe WITHOUT a tracking flag, and cannot break
-    ** racf_auth()'s cross-task serialization (the property #64 relies on):
-    ** unlock() is DEQ RET=HAVE (@@lkunlk.c -> @@enqdeq.c: pl.opt=HAVE,
-    ** SVC 48, returns pl.rc — never ABENDs), and MVS ENQ ownership is
-    ** per-TCB, so a DEQ from THIS task can only release an ENQ THIS task
-    ** owns.  Outside the window (the common case) we don't own it: DEQ
-    ** RET=HAVE returns RC=8 and releases nothing — it can never touch a
-    ** concurrent worker's lock. */
+    ** The window is PASS: ftpd_auth_pass() -> racf_login(), which brackets
+    ** its RACINIT with lock(asxb)/unlock(asxb) (raclogin.c:52,156), and
+    ** dispatch runs under try().  racf_logout() takes the same lock, but
+    ** ftpd calls it from ftpd_session_free() outside try(), where an ABEND
+    ** ends the task and MVS DEQs for us.  racf_auth() no longer takes the
+    ** lock at all (libc370 #58) — this step outlived that caller.
+    **
+    ** This is ownership-safe WITHOUT a tracking flag: unlock() is DEQ
+    ** RET=HAVE (@@lkunlk.c -> @@enqdeq.c: pl.opt=HAVE, SVC 48, returns
+    ** pl.rc — never ABENDs), and MVS ENQ ownership is per-TCB, so a DEQ
+    ** from THIS task can only release an ENQ THIS task owns.  Outside the
+    ** window (the common case) we don't own it: DEQ RET=HAVE returns RC=8
+    ** and releases nothing — it can never touch a concurrent worker's
+    ** lock.  Delete this step only once racf_login()/racf_logout() stop
+    ** taking the ASXB lock. */
     {
         unsigned *psa  = (unsigned *)0;
         unsigned *ascb = (unsigned *)psa[0x224/4];  /* PSAAOLD  -> ASCB */

--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -266,10 +266,11 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
     ** must be upper-case:
     **   SITE ABEND        -> ABEND (S0C4) OUTSIDE any lock window; recovery's
     **                        unlock(asxb) must be a no-op and leave every
-    **                        concurrent session's racf_auth() undisturbed.
+    **                        concurrent session's login/teardown undisturbed.
     **   SITE ABEND=LOCK   -> acquire the ASXB ENQ, then ABEND holding it;
     **                        recovery must DEQ the orphaned ENQ (a concurrent
-    **                        session parked in racf_auth() then proceeds).
+    **                        session parked in racf_login() — the real window,
+    **                        PASS under try() — or racf_logout() proceeds).
     **   SITE ABEND=XFER   -> arm the next MVS RETR to ABEND mid-transfer
     **                        (cur_file set + data connection open); exercises
     **                        recovery's fclose(cur_file) + clear-before-close.


### PR DESCRIPTION
Closes #81, but not the way the issue proposed — see below.

## What #81 got right

Three comments named `racf_auth()` as the mechanism they document, and after
mvslovers/libc370#58 that mechanism is gone from `racf_auth()`: it passes the
ACEE in the RACHECK plist and touches neither ASXBSENV nor the lock. Those
comments are corrected here (`ftpd#ses.c` steps 1 and 2, `ftpd#sit.c`'s
`SITE ABEND=LOCK` hook).

## What #81 got wrong

The issue says the DEQ in recovery step 2 "becomes a permanent no-op" and can
be deleted. It does not, and it cannot. `racf_auth()` was never the only caller
that takes the ASXB ENQ:

| libc370 function | takes `lock(asxb)` | touches ASXBSENV | called from ftpd under `try()` |
|---|---|---|---|
| `racf_auth()` | no (after #58) | no (after #58) | yes — every pre-check |
| `racf_login()` | **yes** (`raclogin.c:52,156`) | no | **yes** — `ftpd_auth_pass()` on PASS |
| `racf_logout()` | **yes** (`raclgout.c:23,93`) | **yes** (`:18,73`) | no — `ftpd_session_free()`, outside `try()` |

So the window step 2 exists for is now **PASS**: an ABEND inside `racf_login()`
leaves the address-space-wide ENQ held by a task that recovery deliberately
keeps alive, and every other session's login and teardown then stalls until
this worker's next command. Deleting the DEQ would reintroduce precisely that.

Step 1's ordering constraint survives for the same reason, with a different
actor: `racf_logout()` still reads ASXBSENV on entry and writes the *observed*
value back on exit. Release the ENQ before resetting ASXBSENV and a worker
parked in `racf_logout()` captures the ABENDing session's user ACEE and parks
it back in the shared field — the hazard #78 removed from ftpd's own sites.

`SITE ABEND=LOCK` therefore still tests something real; only its wording needed
fixing.

## Follow-up

`racf_login()`/`racf_logout()` deserve the same treatment `racf_auth()` got:
neither needs the lock, and `racf_logout()`'s ASXBSENV save/restore is
redundant because RACINIT already receives `ACEE=` and RAKF clears the field
itself when it holds the deleted ACEE. Filed as mvslovers/libc370#64. Once that
lands, step 2 and the debug hook can go — a single commit, recorded against a
libc370 commit date since that repo has no tags.

Comments only; no functional change. Builds clean with `-Wall -Werror`.

