### PR TITLE
Accept RACHECK rc=4 (resource not protected) as allowed (#82)

### DIFF
--- a/doc/FTPD_RAKF_SETUP.md
+++ b/doc/FTPD_RAKF_SETUP.md
@@ -107,6 +107,29 @@ production.
 
 ---
 
+## 3.5 How FTPD Reads a RACHECK Result
+
+Every authorization decision — the `FTPAUTH` gate above and every DATASET
+check in §4 — goes through `racf_auth()`, whose return code is the SAF
+return code:
+
+| RC | Meaning | FTPD |
+|----|---------|------|
+| 0  | A profile permits the access | allow |
+| 4  | **No profile covers the resource** ("not protected") | allow |
+| 8  | A profile refuses the access | deny — `550` / `530` |
+
+RC=4 is an allow, not a refusal: it is the same answer data set OPEN,
+IDCAMS and the catalog act on, so refusing it would make FTP the only path
+on the system that cannot reach an unprotected data set.  This is what
+makes §3.4 work — an undefined `FTPAUTH` answers 4, and login proceeds.
+
+Note that a `DATASET *` catch-all profile — present in the stock MVS/CE and
+TK4- configurations — covers every data set name, so on those systems RC=4
+never occurs for the DATASET class.
+
+---
+
 ## 4. Dataset Access Control
 
 FTPD performs RACHECK against the `DATASET` class before every

--- a/include/ftpd#aut.h
+++ b/include/ftpd#aut.h
@@ -19,6 +19,26 @@
 int ftpd_auth_pass(ftpd_session_t *sess, const char *password)
                                                     asm("FTPAUTPS");
 
+/* racf_auth() return code: no profile covers the resource.  SAF calls this
+** "resource not protected"; it is an ALLOW, not a denial — the same answer
+** data set OPEN, IDCAMS and the catalog act on. */
+#define FTPD_RACF_NOTPROT       4
+
+/*
+** True if a racf_auth() return code means the access may proceed: 0 (a
+** profile permits it) or 4 (no profile covers the resource).  Everything
+** else — 8 and up — is a refusal.
+**
+** Testing rc != 0 alone is wrong and was only ever harmless by accident:
+** libc370 set RACHECK flag byte 0x10 believing it meant LOG=NONE, when it
+** is DSTYPE=V, and with that flag RAKF answered 0 where it should answer 4.
+** With the flag corrected (libc370 #63) the 4 becomes visible, so both call
+** sites must accept it or every unprotected resource turns into a denial —
+** for FACILITY/FTPAUTH that means refusing every login on a system without
+** that profile, which doc/FTPD_RAKF_SETUP.md §3.4 documents as allowed.
+*/
+int ftpd_racf_allowed(int rc)                       asm("FTPRACOK");
+
 /*
 ** Identity switch around MVS services that must authorize against the
 ** logged-in user (dataset OPEN, SVC 99, IDCAMS, JES internal reader).

--- a/src/ftpd#aut.c
+++ b/src/ftpd#aut.c
@@ -20,6 +20,7 @@ ftpd_auth_pass(ftpd_session_t *sess, const char *password)
 {
     ACEE *acee;
     int racf_rc;
+    int auth_rc;
     char user[9];
     char pass[9];
 
@@ -60,8 +61,12 @@ ftpd_auth_pass(ftpd_session_t *sess, const char *password)
     }
 
     /* Check FACILITY class authorization */
-    if (racf_auth(acee, FTPD_FACILITY_CLASS, FTPD_FACILITY_RESOURCE,
-                  RACF_ATTR_READ) != 0) {
+    auth_rc = racf_auth(acee, FTPD_FACILITY_CLASS, FTPD_FACILITY_RESOURCE,
+                        RACF_ATTR_READ);
+    if (auth_rc == FTPD_RACF_NOTPROT)
+        ftpd_log(LOG_DEBUG, "%s: %s.%s has no profile — FTP access is open",
+                 __func__, FTPD_FACILITY_CLASS, FTPD_FACILITY_RESOURCE);
+    if (!ftpd_racf_allowed(auth_rc)) {
         ftpd_log(LOG_WARN, "%s: %s not authorized for %s.%s",
                  __func__, user, FTPD_FACILITY_CLASS,
                  FTPD_FACILITY_RESOURCE);
@@ -135,4 +140,17 @@ ftpd_acee_leave(ftpd_session_t *sess)
 {
     if (sess->acee)
         racf_set_acee(sess->server->stc_acee);
+}
+
+/* --------------------------------------------------------------------
+** Does this racf_auth() return code allow the access?
+**
+** 0 = a profile permits it, 4 = no profile covers the resource.  Both are
+** SAF "allowed"; 8 and up are refusals.  See ftpd#aut.h for why testing
+** rc != 0 alone survived this long.
+** ----------------------------------------------------------------- */
+int
+ftpd_racf_allowed(int rc)
+{
+    return (rc == 0 || rc == FTPD_RACF_NOTPROT);
 }

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -104,10 +104,21 @@ dsn_match(const char *pattern, const char *name)
 static int
 check_dataset_access(ftpd_session_t *sess, const char *dsn, int attr)
 {
+    int rc;
+
     if (!sess->acee)
         return 0;   /* no ACEE available — skip check */
 
-    if (racf_auth(sess->acee, "DATASET", dsn, attr) != 0) {
+    rc = racf_auth(sess->acee, "DATASET", dsn, attr);
+
+    /* Not protected: no profile covers this data set.  OPEN, IDCAMS and the
+    ** catalog all proceed on that answer, so refusing here would make FTPD
+    ** stricter than every other path to the same data set on the system. */
+    if (rc == FTPD_RACF_NOTPROT)
+        ftpd_log(LOG_DEBUG, "%s: %s is not protected by RAKF — allowed for %s",
+                 __func__, dsn, sess->user);
+
+    if (!ftpd_racf_allowed(rc)) {
         ftpd_log(LOG_WARN, "%s: %s access denied to %s for %s",
                  __func__, attr == RACF_ATTR_READ    ? "READ"    :
                            attr == RACF_ATTR_UPDATE  ? "UPDATE"  :


### PR DESCRIPTION
Closes #82. **Merge this before libc370#63** — after that lands, an unfixed
FTPD refuses every login on a system without an `FTPAUTH` profile.

## Change

`ftpd_racf_allowed(rc)` in `ftpd#aut.c`, used at both `racf_auth()` call sites:

| RC | SAF meaning | before | after |
|----|-------------|--------|-------|
| 0 | a profile permits the access | allow | allow |
| 4 | no profile covers the resource | **deny** | allow |
| 8+ | a profile refuses the access | deny | deny |

* `src/ftpd#aut.c:64` — the `FACILITY`/`FTPAUTH` login gate
* `src/ftpd#mvs.c:112` — `check_dataset_access()`

Each site logs the rc=4 case at `LOG_DEBUG` (default level is `LOG_INFO`, so
no new noise) — worth having, because "this resource is unprotected" is the
one outcome an operator cannot infer from the reply the client sees.

`doc/FTPD_RAKF_SETUP.md` gains §3.5 with the return-code contract. §3.4 already
documented that an undefined `FTPAUTH` leaves FTP access open; it just never
said which return code delivers that, which is precisely the gap this bug fell
into.

## Why the old code looked correct

libc370 set RACHECK flag byte `0x10` believing it meant `LOG=NONE`, when that
bit is `DSTYPE=V`. With it, RAKF answers 0 where it should answer 4, so the
distinction between "permitted" and "not protected" never reached FTPD.

That also closes an open thread from #80, which I closed as invalid after
measuring on mvsdev that a resource with no profile (`FACILITY`/`FTPAUTH`,
absent from `SYS1.SECURE.CNTL(PROFILES)`) still let logins through. The
observation was right and the cause is now known: the 4 was never produced,
not normalised away. libc370#63 produces it; this PR handles it.

## Behaviour

No change today, by construction — with the current library rc=4 never
arrives. After libc370#63 the behaviour stays what it is now, rather than
silently tightening into a lockout.

Worth knowing: a `DATASET *` catch-all — stock on MVS/CE and TK4- — covers
every data set name, so rc=4 does not occur for the DATASET class on those
systems. The login gate is where this actually bites.

## Verification

Builds clean with `-Wall -Werror`. The rc=4 path cannot be exercised until
libc370#63 is in the sysroot, so the acceptance check belongs to that landing:
on a system with **no** `FTPAUTH` profile, login must still return 230, and
`MVSCE02` against `SYS1.SECURE.*` must still return `550 Access denied` — the
same pair used to settle #80.

Does not touch recovery step 2 or the `SITE ABEND=LOCK` hook; those wait for
libc370#64 as agreed in #81.
