### PR TITLE
Serialize the identity windows (#79)

### DIFF
--- a/include/ftpd#aut.h
+++ b/include/ftpd#aut.h
@@ -52,8 +52,26 @@ int ftpd_racf_allowed(int rc)                       asm("FTPRACOK");
 ** to zero — which RAKF treats as "access permitted" (ICHSFR00: no ACEE ->
 ** RACHGOOD).  Restoring a constant makes both states unreachable.
 **
+** Enter also takes an ENQ on server->acee_lock, so only one window is open
+** in the address space at a time (#79).  One field cannot hold two
+** identities: without it, a worker dispatching inside another session's
+** window authorizes as that session's user, which for a pre-checked
+** operation means a spurious denial — S913 out of OPEN, i.e. an ABEND and
+** a recovery, for what should be a wait of a few milliseconds.
+**
+** INVARIANT, load-bearing for deadlock freedom: a session must not enter a
+** window while holding a data set ENQ (an open DCB or an allocated DD).
+** Every window today opens or allocates INSIDE itself and releases before
+** the next one — RETR/STOR fopen and then transfer outside the window, MKD
+** frees its DD right after, DELE/RMD/RNTO hold nothing.  So a worker inside
+** a window never waits on a resource another worker can only release after
+** acquiring this ENQ.  Keep it that way: a window opened around an already
+** open data set can deadlock the address space.
+**
 ** Both are no-ops for an unauthenticated session (sess->acee == NULL), and
-** must be used in matched pairs around the shortest possible window.
+** must be used in matched pairs around the shortest possible window.  They
+** must NOT nest: the ENQ is not recursive, so an inner leave() would end
+** the outer window's exclusivity.
 */
 void ftpd_acee_enter(ftpd_session_t *sess)          asm("FTPACEEN");
 void ftpd_acee_leave(ftpd_session_t *sess)          asm("FTPACELV");

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -154,6 +154,11 @@ struct ftpd_server {
     ACEE            *stc_acee;      /* STC identity ACEE, captured at
                                     ** init; recovery resets ASXBSENV
                                     ** to this after an ABEND          */
+    int             acee_lock;      /* never read — its ADDRESS is the
+                                    ** ENQ resource serializing the
+                                    ** identity windows (ftpd#aut.c).
+                                    ** Lives in the server struct so it
+                                    ** is one anchor per address space  */
     int             listen_sock;    /* listening socket fd            */
     CTHDMGR         *mgr;          /* thread manager                */
     CTHDTASK        *sock_task;    /* socket listener thread         */

--- a/src/ftpd#aut.c
+++ b/src/ftpd#aut.c
@@ -7,6 +7,7 @@
 #include "ftpd.h"
 #include "ftpd#ses.h"
 #include "ftpd#aut.h"
+#include "cliblock.h"               /* lock()/unlock() — identity window */
 
 #define FTPD_MAX_AUTH_ATTEMPTS  3
 #define FTPD_FACILITY_RESOURCE  "FTPAUTH"
@@ -117,20 +118,40 @@ ftpd_auth_pass(ftpd_session_t *sess, const char *password)
 }
 
 /* --------------------------------------------------------------------
-** Switch the address space to this session's security environment.
+** Open this session's identity window: take the address-space-wide ENQ,
+** then switch ASXBSENV to the session's ACEE.
 **
-** No-op for an unauthenticated session.  See ftpd#aut.h for why leave()
-** restores a constant instead of the value observed here (#64).
+** No-op for an unauthenticated session — with no ACEE there is nothing to
+** switch, so there is nothing to serialize either.
+**
+** lock() waits rather than failing, which is why enter() has no error
+** return and no call site needs a failure path.  That is safe only while
+** the no-open-data-set invariant in ftpd#aut.h holds; read it before adding
+** a window.  RC=8 means this task already holds the ENQ, i.e. two windows
+** nested — a coding error the ENQ cannot express, so say so loudly.
 ** ----------------------------------------------------------------- */
 void
 ftpd_acee_enter(ftpd_session_t *sess)
 {
-    if (sess->acee)
-        racf_set_acee(sess->acee);
+    if (!sess->acee)
+        return;
+
+    if (lock(&sess->server->acee_lock, LOCK_EXC) == 8)
+        ftpd_log(LOG_ERROR, "%s: identity window already open on this task "
+                 "— nested enter, window exclusivity is broken", __func__);
+
+    racf_set_acee(sess->acee);
 }
 
 /* --------------------------------------------------------------------
-** Restore the STC identity captured at startup (ftpd.c: server->stc_acee).
+** Close the window: restore the STC identity captured at startup
+** (ftpd.c: server->stc_acee), then release the ENQ.
+**
+** ORDER IS LOAD-BEARING.  Releasing first would let the next window's owner
+** set its own ACEE, and this task would then overwrite it with the STC
+** identity — handing a live window the wrong identity, which is the very
+** failure the ENQ exists to prevent.  ABEND recovery resets and releases in
+** the same order, for the same reason.
 **
 ** stc_acee may be NULL if the startup RACINIT failed — that is still the
 ** correct value to restore, and is the same value ABEND recovery writes.
@@ -138,8 +159,11 @@ ftpd_acee_enter(ftpd_session_t *sess)
 void
 ftpd_acee_leave(ftpd_session_t *sess)
 {
-    if (sess->acee)
-        racf_set_acee(sess->server->stc_acee);
+    if (!sess->acee)
+        return;
+
+    racf_set_acee(sess->server->stc_acee);
+    unlock(&sess->server->acee_lock, LOCK_EXC);
 }
 
 /* --------------------------------------------------------------------

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -10,6 +10,7 @@
 #include "ftpd#dat.h"
 #include "ftpd#ufs.h"
 #include "libufs.h"                 /* UFSFILE, ufs_fclose()          */
+#include "cliblock.h"               /* unlock() — identity window ENQ */
 
 /* --------------------------------------------------------------------
 ** Allocate and initialize a new session
@@ -253,10 +254,10 @@ ftpd_run_command(ftpd_session_t *sess, const char *cmd, const char *arg)
 **
 ** This function is itself run under try() by the caller, so a re-ABEND in
 ** a cleanup step is contained.  Ordering is therefore deliberate: restore
-** the identity first (so it holds even on a re-ABEND); WTO + tell the
-** client next; and only then perform the one step that can plausibly
-** re-ABEND (fclose on a possibly-corrupt DCB), so a cleanup failure can
-** never leave the client hanging.
+** the identity and release its ENQ first (so they hold even on a re-ABEND);
+** WTO + tell the client next; and only then perform the one step that can
+** plausibly re-ABEND (fclose on a possibly-corrupt DCB), so a cleanup
+** failure can never leave the client hanging.
 **
 ** 'verb' is the parsed FTP command word only (no arguments) — never the
 ** raw command line, which for PASS would contain the password.
@@ -289,7 +290,24 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
     ** re-ABENDs. */
     racf_set_acee(sess->server->stc_acee);
 
-    /* 2. Count + WTO now, before the risky cleanup, so the diagnostic
+    /* 2. Release the identity window's ENQ, which the ABEND skipped past.
+    ** MVS DEQs a task's ENQs at task termination, but recovery keeps the
+    ** task alive, so an orphaned window would stall every other session's
+    ** data set access until this worker's next command — and there is no
+    ** next command for a session that then sits idle.
+    **
+    ** MUST follow step 1, and for the same reason leave() resets before it
+    ** unlocks: release first and the next window's owner sets its ACEE,
+    ** which step 1 would then overwrite with the STC identity.
+    **
+    ** Ownership-safe without a tracking flag: unlock() is DEQ RET=HAVE
+    ** (@@lkunlk.c -> @@enqdeq.c: pl.opt=HAVE, SVC 48, returns pl.rc — never
+    ** ABENDs) and MVS ENQ ownership is per-TCB, so this can only release an
+    ** ENQ this task owns.  ABEND outside a window (the common case): RC=8,
+    ** nothing released, no concurrent window disturbed. */
+    unlock(&sess->server->acee_lock, LOCK_EXC);
+
+    /* 3. Count + WTO now, before the risky cleanup, so the diagnostic
     ** survives even a cleanup re-ABEND.  total_recover accumulates over
     ** the STC lifetime (per-session growth is bounded by FTPD_MAX_RECOVER)
     ** so leaked-resource accumulation from the documented residual windows
@@ -308,12 +326,12 @@ ftpd_session_recover(ftpd_session_t *sess, unsigned abcode, const char *verb)
                      "total=%u", abcode, verb, sess->ctrl_sock,
                      sess->server->total_recover);
 
-    /* 3. Tell the client before touching in-flight resources, so a
+    /* 4. Tell the client before touching in-flight resources, so a
     ** re-ABEND in cleanup cannot leave it hanging until timeout. */
     ftpd_session_reply(sess, FTP_451,
         "Requested action aborted: local error in processing.");
 
-    /* 4. Release the in-flight transfer handle.  Clear the tracking field
+    /* 5. Release the in-flight transfer handle.  Clear the tracking field
     ** BEFORE closing so a re-ABEND in the close (contained by the caller's
     ** try()) can never cause a double close on a subsequent recovery.  At
     ** most one of these is set (a session is in MVS or UFS mode, one

--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -11,6 +11,9 @@
 #include "ftpd.h"
 #include "ftpd#ses.h"
 #include "ftpd#sit.h"
+#ifdef FTPD_DEBUG_ABEND
+#include "ftpd#aut.h"            /* ftpd_acee_enter() — ABEND=LOCK  */
+#endif
 
 /* --------------------------------------------------------------------
 ** Helper: parse "KEY=VALUE" from token.
@@ -261,9 +264,13 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
     ** Requires an authenticated session (SITE is already post-auth; the
     ** explicit check keeps this from ever being a pre-auth DoS).  Keyword
     ** must be upper-case:
-    **   SITE ABEND        -> ABEND (S0C4) now; recovery must reset ASXBSENV
-    **                        to the STC identity, answer the client and leave
-    **                        the worker serving.
+    **   SITE ABEND        -> ABEND (S0C4) OUTSIDE any identity window;
+    **                        recovery's unlock() must be a no-op and leave
+    **                        every concurrent window undisturbed.
+    **   SITE ABEND=LOCK   -> open an identity window (ACEE switched, ENQ
+    **                        held), then ABEND inside it; recovery must put
+    **                        the STC identity back AND release the ENQ, or
+    **                        every other session's data set access stalls.
     **   SITE ABEND=XFER   -> arm the next MVS RETR to ABEND mid-transfer
     **                        (cur_file set + data connection open); exercises
     **                        recovery's fclose(cur_file) + clear-before-close.
@@ -283,6 +290,10 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
                 "DEBUG: next RETR will ABEND mid-transfer");
             return 0;
         }
+
+        /* ABEND=LOCK: ABEND with the identity window open. */
+        if (arg[5] == '=' && (arg[6] == 'L' || arg[6] == 'l'))
+            ftpd_acee_enter(sess);
 
         ftpd_log_wto("FTPD072W DEBUG ABEND injection: SITE %s", arg);
         *trap = 0;                     /* force S0C4 */


### PR DESCRIPTION
Closes #79, the last piece of #64.

## What was left

ASXBSENV holds one identity; ftpd runs one TCB per session. Two sessions
inside `ftpd_acee_enter()`/`leave()` at the same time means one authorizes as
the other's user. #78 made the *resting* value constant, so nothing persists —
but the overlap itself remained, and with the pre-checks gating entitlement it
surfaces as a spurious denial out of OPEN, i.e. **S913: an ABEND and a
recovery**, for what should be a few milliseconds of waiting. Recovery has
documented windows where it leaks a DD, so this is worth more than its
nuisance value.

## Why it can be fixed now

ftpd is the only writer of ASXBSENV left in the address space: `racf_auth()`
stopped touching it in libc370#58, `racf_login()`/`racf_logout()` in
libc370#64. Mutual exclusion between ftpd's own windows is therefore
sufficient — nothing else can walk into the field.

## Change

* `enter()` takes an ENQ on `server->acee_lock` (SCOPE=STEP, so per address
  space — the same scope ASXBSENV has), then switches the ACEE.
* `leave()` restores the STC identity **then** releases the ENQ. Releasing
  first would let the next window's owner set its ACEE and this task would
  overwrite it — the exact failure the ENQ prevents. Recovery does the same
  two steps in the same order, and both places say why.
* Recovery regains a DEQ — this time for a lock ftpd actually holds. An ABEND
  inside a window would otherwise strand the ENQ for a task that recovery
  keeps alive, stalling every other session's data set access with no next
  command to release it.
* `SITE ABEND=LOCK` regains its subject: it now ABENDs **inside** a window, so
  one injection exercises both recovery duties — identity reset and ENQ
  release.

Only windows serialize. Data transfer, listing formatting, and the control
conversation all happen outside them.

## The invariant that makes blocking safe

`lock()` waits rather than failing, so no call site needs an error path. That
holds only because **no window is entered while the session holds a data set
ENQ**: RETR/STOR open inside the window and transfer outside it, MKD frees its
DD immediately after, DELE/RMD/RNTO hold nothing. So a worker inside a window
never waits on something another worker can only release by first acquiring
this ENQ — no cycle. This is written down in `ftpd#aut.h`, because a future
window wrapped around an already-open data set would deadlock the address
space, and that would not be obvious to whoever adds it.

Verified mechanically for this change: all nine call sites are straight-line
between `enter()` and `leave()` — no `return`, `goto`, `break` or `continue`
in between, so no path leaves a window open.

## Known cost

DELE, RMD and RNTO hold the window across a whole `idcams()` invocation —
seconds, during which other sessions' data set opens wait. Shrinking those to
SCRATCH/RENAME via CAMLST is the natural follow-up and is filed separately;
it is a rewrite of three commands and did not belong in this change.

## Verification

`make` clean with `-Wall -Werror`, and `ftpd#sit.c` compiled separately with
`-DFTPD_DEBUG_ABEND` since the injection hooks are otherwise out of the build.

The overlap itself has no automated reproduction here — it needs two
authenticated sessions racing inside an APF-authorized address space. On the
target it is exercised by `SITE ABEND=LOCK` (recovery must release the ENQ, so
a second session's RETR proceeds instead of hanging) plus parallel
LIST/RETR/STOR/DELE from two clients. That check is still outstanding: mvsdev
runs a build older than `b53c7dd` and predates every change in this series.
