### PR TITLE
Reject JESINTERFACELEVEL on SITE and name the parameter we reject

### DIFF
--- a/src/ftpd#sit.c
+++ b/src/ftpd#sit.c
@@ -197,10 +197,15 @@ site_apply_one(ftpd_session_t *sess,
 
     /* --- JES parameters --- */
 
-    if (strcmp(key, "JESINTERFACELEVEL") == 0) {
-        sess->jes_level = atoi(val);
-        return 0;
-    }
+    /* JESINTERFACELEVEL is deliberately NOT accepted here.  On z/OS it is a
+    ** server setting in FTP.DATA, not something a client may change per
+    ** session, and z/OS answers a client that tries with "Unrecognized
+    ** parameter".  Accepting it was worse than either: ftpd stored the value
+    ** in sess->jes_level and no code has ever read it, so the 200 reply
+    ** promised a scoping level that does not exist.  What that level governs
+    ** on z/OS -- who may see and fetch another user's spool -- is tracked as
+    ** its own piece of work; until it exists, say so honestly by falling
+    ** through to the unrecognized-parameter path below. */
 
     if (strcmp(key, "JESJOBNAME") == 0) {
         strncpy(sess->jes_jobname, val, sizeof(sess->jes_jobname) - 1);
@@ -245,6 +250,8 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
     char key[32];
     char val[64];
     char warn[128];
+    char badtok[96];            /* first unrecognized token, verbatim */
+    char badmsg[160];
     const char *p;
     const char *end;
     int tlen;
@@ -301,6 +308,7 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
 #endif
 
     warn[0] = '\0';
+    badtok[0] = '\0';
     n_tokens = 0;
     n_unrecognized = 0;
     p = arg;
@@ -321,8 +329,15 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
         tok[tlen] = '\0';
 
         parse_kv(tok, key, sizeof(key), val, sizeof(val));
-        if (site_apply_one(sess, key, val, warn, sizeof(warn)) != 0)
+        if (site_apply_one(sess, key, val, warn, sizeof(warn)) != 0) {
+            /* Keep the first offender verbatim for the reply — z/OS names it,
+            ** and "which one?" is the only question the old wording left. */
+            if (badtok[0] == '\0') {
+                strncpy(badtok, tok, sizeof(badtok) - 1);
+                badtok[sizeof(badtok) - 1] = '\0';
+            }
             n_unrecognized++;
+        }
         n_tokens++;
         p = end;
     }
@@ -336,8 +351,10 @@ ftpd_site_dispatch(ftpd_session_t *sess, const char *arg)
 
     /* Send exactly one reply for the entire command */
     if (n_unrecognized > 0) {
+        snprintf(badmsg, sizeof(badmsg),
+                 "Unrecognized parameter '%s' on SITE command.", badtok);
         ftpd_session_reply_multi(sess, FTP_200,
-            "Unrecognized parameter on SITE command.",
+            badmsg,
             "SITE command was accepted");
     } else if (warn[0] != '\0') {
         ftpd_session_reply_multi(sess, FTP_200,


### PR DESCRIPTION
Found by comparing our SITE replies against z/OS side by side.

## z/OS vs. us

```
z/OS                                          ftpd (before)
> site JESINTERFACELEVEL=2                    > site JESINTERFACELEVEL=2
< 200-Unrecognized parameter                  < 200 SITE command was accepted
<     'JESINTERFACELEVEL=2' on SITE command.
< 200 SITE command was accepted
```

z/OS rejects it because `JESINTERFACELEVEL` is a **server** setting in
`FTP.DATA`, not something a session may change. We accepted it — and stored it
in `sess->jes_level`, which **no code has ever read**: the field is written in
`ftpd#ses.c:60` from the config and in `ftpd#sit.c` from SITE, and consulted
nowhere. So the `200` promised a scoping level that does not exist, in exactly
the area where a client most wants to know the rules.

## Change

* The `JESINTERFACELEVEL` branch in `site_apply_one()` is gone, so the
  parameter falls through to the unrecognized path. A comment says why, so it
  does not get "helpfully" added back.
* The unrecognized reply now names the offender, as z/OS does:
  `200-Unrecognized parameter 'JESINTERFACELEVEL=2' on SITE command.` The first
  unrecognized token is kept verbatim, so the client sees what it sent rather
  than the uppercased key. This applies to every unrecognized parameter, not
  just this one — the old wording never said which of several tokens was at
  fault.

Left alone deliberately: the `JESINTERFACELEVEL` key in `FTPDPRM`. It is
equally inert today, but it is where the setting belongs once the scoping
rules exist, and removing it would break existing config members for nothing.
Noted in the feature issue below.

## Related

What `JESINTERFACELEVEL` governs on z/OS — who may list and fetch another
user's spool — is filed as a feature request (#90). Pulling this thread showed
ftpd currently has no authorization on spool access at all: `JESOWNER` is a
display filter the client sets itself, and `find_job()` looks up purely by
JOBID. Not fixed here; that needs a design, not a patch.

## Verification

Builds clean with `-Wall -Werror`, and `ftpd#sit.c` also compiles with
`-DFTPD_DEBUG_ABEND`. Behaviour on the target after the next deploy: `SITE
JESINTERFACELEVEL=2` must give the two-line 200 reply naming the parameter, and
the other SITE parameters must keep working (`SITE RECFM=FB`, `SITE
FILETYPE=JES`, lowercase forms included).

