### PR TITLE
Answer SIZE for MVS data sets with 502 instead of a wrong number (#88)

### DIFF
--- a/doc/FTPD_CONCEPT.md
+++ b/doc/FTPD_CONCEPT.md
@@ -99,9 +99,17 @@ Standard FTP commands that MUST be supported:
 | `ABOR` | Abort transfer |
 | `REST` | Restart transfer (RFC 3659) |
 | `FEAT` | Feature negotiation (RFC 2389) |
-| `SIZE` | File size (RFC 3659) |
-| `MDTM` | File modification time (RFC 3659) |
+| `SIZE` | File size (RFC 3659) — **UFS only**, `502` for MVS data sets |
+| `MDTM` | File modification time (RFC 3659) — **UFS only**, `502` for MVS data sets |
 | `HELP` | Command help |
+
+`SIZE` and `MDTM` are optional RFC 3659 extensions and are answered only in
+UFS mode. A data set has no byte count to report: RFC 3659 asks for the exact
+number of bytes the transfer would deliver, and MVS metadata cannot supply it —
+for F/FB the last block may be short and by how much is recorded nowhere, so
+ten 80-byte records in a 3120-byte block are indistinguishable from a full
+block. z/OS FTP does not implement `SIZE` for data sets either. Clients use the
+value for resume offsets, so an estimate is worse than an honest `502`.
 
 ### 2.2 z/OS-Compatible SITE Commands
 

--- a/include/ftpd#mvs.h
+++ b/include/ftpd#mvs.h
@@ -39,13 +39,6 @@ int ftpd_mvs_list(ftpd_session_t *sess, const char *arg, int nlst)
                                                     asm("FTPMVLST");
 
 /*
-** Get dataset size (used tracks * blksize approximation).
-** Returns size in bytes, or -1 on error.
-*/
-long ftpd_mvs_size(ftpd_session_t *sess, const char *dsn)
-                                                    asm("FTPMVSIZ");
-
-/*
 ** RETR — send dataset/member to client via data connection.
 */
 int ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -465,14 +465,16 @@ ftpd_cmd_dispatch(ftpd_session_t *sess, const char *cmd, const char *arg)
     if (strcmp(cmd, "SIZE") == 0) {
         if (sess->fsmode == FS_UFS)
             return ftpd_ufs_size(sess, arg);
-        {
-            long sz = ftpd_mvs_size(sess, arg);
-            if (sz >= 0)
-                ftpd_session_reply(sess, FTP_213, "%ld", sz);
-            else
-                ftpd_session_reply(sess, FTP_550, "Dataset not found");
-            return 0;
-        }
+        /* MVS data sets have no byte count to report.  RFC 3659 wants the
+        ** exact transfer size, and a data set's metadata cannot give it: for
+        ** F/FB the last block may be short and by how much is recorded
+        ** nowhere, so 10 records of 80 bytes in a 3120-byte block look like
+        ** 3120.  z/OS FTP does not implement SIZE for data sets either, and
+        ** SIZE is an optional extension -- so answer like MDTM does rather
+        ** than invent a number clients use for resume offsets (#88). */
+        ftpd_session_reply(sess, FTP_502,
+                           "SIZE not implemented for MVS data sets");
+        return 0;
     }
     if (strcmp(cmd, "MDTM") == 0) {
         if (sess->fsmode == FS_UFS)

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -1019,48 +1019,6 @@ ftpd_mvs_list(ftpd_session_t *sess, const char *arg, int nlst)
 }
 
 /* --------------------------------------------------------------------
-** SIZE — get approximate dataset size
-** ----------------------------------------------------------------- */
-long
-ftpd_mvs_size(ftpd_session_t *sess, const char *dsn)
-{
-    char name[FTPD_MAX_DSN_LEN + 2];
-    LOCWORK lw;
-    DSCB dscb;
-    int rc;
-    long size;
-
-    if (resolve_dsn(sess, dsn, name, sizeof(name), 0) != 0)
-        return -1;
-
-    memset(&lw, 0, sizeof(lw));
-    rc = __locate(name, &lw);
-    if (rc != 0)
-        return -1;
-
-    memset(&dscb, 0, sizeof(dscb));
-    rc = __dscbdv(name, lw.volser, &dscb);
-    if (rc != 0)
-        return -1;
-
-    /* Approximate: used_tracks * blksize (rough estimate) */
-    {
-        unsigned short blksize = dscb.dscb1.blksz;
-
-        if (blksize == 0)
-            blksize = dscb.dscb1.lrecl;
-        if (blksize == 0)
-            return 0;
-
-        /* lstar TTR: first 2 bytes = track count */
-        size = ((long)dscb.dscb1.lstar[0] << 8) | dscb.dscb1.lstar[1];
-        size = size * blksize;
-    }
-
-    return size;
-}
-
-/* --------------------------------------------------------------------
 ** Helper: split DSN(MEMBER) into base dataset name and member name.
 ** If no parentheses, member[0] = '\0'.
 ** Modifies dsn in place (strips the member part).


### PR DESCRIPTION
Closes #88 — by removing the answer rather than repairing it. Reasoning below,
since the issue proposed fixing the arithmetic.

## Why not fix the number

Every SIZE answer measured against what RETR actually delivered was wrong:

| Data set | SIZE was | RETR delivers |
|---|---|---|
| PS, FB 80, 10 records | 0 | 800 |
| PDS member | 550 Dataset not found | 2160 |
| PDS | 114240 | 12800 |

Two of the three causes are ordinary bugs — the member case never called
`split_member()`, and `DS1LSTAR` was read as a track count when it is a TTR.
The third is not a bug but a limit. RFC 3659 asks for **the exact number of
bytes the transfer would deliver**, and a data set's metadata cannot supply it:
for F/FB the last block may be short, and by how much is recorded nowhere. Ten
80-byte records in a 3120-byte block are indistinguishable from a full block.
The only route to a correct number is to read the data set — precisely the work
the following RETR does anyway.

`SIZE` is an optional RFC 3659 extension, and z/OS FTP does not implement it
for data sets. So the honest answer is the one `MDTM` already gives two lines
further down in the same dispatcher:

```
502 SIZE not implemented for MVS data sets
```

Clients use SIZE for resume offsets. An over-estimate is not a cosmetic defect
there, which is what tips this away from "return a best guess and document it".

## Change

* `ftpd#cmd.c` — MVS mode answers `502`; UFS mode still calls `ftpd_ufs_size()`,
  which reports a real byte count.
* `ftpd#mvs.c` / `ftpd#mvs.h` — `ftpd_mvs_size()` and its declaration are
  removed rather than left to rot. Verified absent from the linked module
  (`FTPMVSIZ` no longer present after a clean build).
* `doc/FTPD_CONCEPT.md` — the command table listed SIZE and MDTM as general
  commands; both are UFS-only. Marked, with the reason.

FEAT keeps announcing `SIZE`, exactly as it announces `MDTM`: FEAT lists what
the server implements, and "UFS but not data sets" is not expressible there.

## Verification

Builds clean with `-Wall -Werror`; clean rebuild confirms the symbol is gone
and the new reply string is in the module. On the target after deploy: `SIZE
'SYS2.PROCLIB(FTPD)'` and `SIZE 'SYS1.HASPCKPT'` must both answer `502`, and
`SIZE` on a UFS path must keep returning `213 <bytes>` — the UFS path is
untouched but worth confirming, since it shares the dispatcher entry.
