### PR TITLE
Rename PDS members with STOW instead of asking LOCATE about them (#92)

### DIFF
--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -1054,6 +1054,49 @@ split_member(char *dsn, char *member, int mbrsz)
 }
 
 /* --------------------------------------------------------------------
+** Helper: is 'member' present in PDS 'dsn'?
+**
+** __locate() answers for the base data set only — it resolves DSN(MEMBER) by
+** ignoring the member entirely — so member existence needs the directory.
+** Reads it with __listpd() under the session identity, exactly as LIST does;
+** the caller has already established that the base data set exists.
+**
+** Returns 1 if the member is there, 0 if it is not (or the directory could
+** not be read, which for the callers here means the same thing: do not
+** proceed).
+** ----------------------------------------------------------------- */
+static int
+member_exists(ftpd_session_t *sess, const char *dsn, const char *member)
+{
+    PDSLIST **pds;
+    char want[8];
+    int found = 0;
+    int i;
+
+    /* Directory entries are 8 bytes, blank padded and not terminated. */
+    memset(want, ' ', sizeof(want));
+    for (i = 0; i < (int)sizeof(want) && member[i]; i++)
+        want[i] = member[i];
+
+    ftpd_acee_enter(sess);
+    pds = __listpd(dsn, member);
+    ftpd_acee_leave(sess);
+
+    if (!pds)
+        return 0;
+
+    for (i = 0; pds[i]; i++) {
+        if (memcmp(pds[i]->name, want, sizeof(want)) == 0) {
+            found = 1;
+            break;
+        }
+    }
+
+    __freepd(&pds);
+    return found;
+}
+
+/* --------------------------------------------------------------------
 ** Helper: format RECFM name for 125 response.
 ** Uses _FILE_RECFM_* constants from clibio.h (FILE struct recfm).
 ** F/FB → "FIX", V/VB → "VAR", U → "UND"
@@ -2008,6 +2051,8 @@ int
 ftpd_mvs_rnfr(ftpd_session_t *sess, const char *arg)
 {
     char dsn[FTPD_MAX_DSN_LEN + 2];
+    char full[FTPD_MAX_DSN_LEN + 2];
+    char member[FTPD_MAX_MBR_LEN + 1];
     LOCWORK lw;
     int rc;
 
@@ -2022,11 +2067,20 @@ ftpd_mvs_rnfr(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    /* Keep the name as given for RNTO, then work on the base name.  Every
+    ** check below is about the data set or its directory, and neither
+    ** __locate() nor a RAKF DATASET profile can be asked about DSN(MEMBER):
+    ** LOCATE resolves the base name and ignores the member, and profiles are
+    ** held under data set names (#92). */
+    strncpy(full, dsn, sizeof(full) - 1);
+    full[sizeof(full) - 1] = '\0';
+    split_member(dsn, member, sizeof(member));
+
     /* RACF access check (ALTER needed for rename) */
     if (check_dataset_access(sess, dsn, RACF_ATTR_ALTER) != 0)
         return 0;
 
-    /* Verify existence */
+    /* Verify existence — of the data set, and of the member if one is named */
     memset(&lw, 0, sizeof(lw));
     if (__locate(dsn, &lw) != 0) {
         ftpd_session_reply(sess, FTP_550,
@@ -2034,8 +2088,14 @@ ftpd_mvs_rnfr(ftpd_session_t *sess, const char *arg)
         return 0;
     }
 
+    if (member[0] && !member_exists(sess, dsn, member)) {
+        ftpd_session_reply(sess, FTP_550,
+            "RNFR fails: %s(%s) does not exist.", dsn, member);
+        return 0;
+    }
+
     /* Store for RNTO */
-    strncpy(sess->rnfr_path, dsn, sizeof(sess->rnfr_path) - 1);
+    strncpy(sess->rnfr_path, full, sizeof(sess->rnfr_path) - 1);
     sess->rnfr_path[sizeof(sess->rnfr_path) - 1] = '\0';
 
     ftpd_session_reply(sess, FTP_350,
@@ -2051,6 +2111,9 @@ int
 ftpd_mvs_rnto(ftpd_session_t *sess, const char *arg)
 {
     char dsn[FTPD_MAX_DSN_LEN + 2];
+    char tmember[FTPD_MAX_MBR_LEN + 1];
+    char src[FTPD_MAX_DSN_LEN + 2];
+    char smember[FTPD_MAX_MBR_LEN + 1];
     LOCWORK lw;
     char cmd[256];
     int rc;
@@ -2071,6 +2134,78 @@ ftpd_mvs_rnto(ftpd_session_t *sess, const char *arg)
         ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
         return 0;
     }
+
+    strncpy(src, sess->rnfr_path, sizeof(src) - 1);
+    src[sizeof(src) - 1] = '\0';
+    split_member(src, smember, sizeof(smember));
+    split_member(dsn, tmember, sizeof(tmember));
+
+    /* A member and a data set are different kinds of thing: STOW renames a
+    ** directory entry, IDCAMS ALTER renames a catalogued data set, and
+    ** neither turns one into the other.  Say which way round it was. */
+    if ((smember[0] != '\0') != (tmember[0] != '\0')) {
+        if (smember[0])
+            ftpd_session_reply(sess, FTP_550,
+                "Rename fails: cannot rename member %s(%s) to data set %s.",
+                src, smember, dsn);
+        else
+            ftpd_session_reply(sess, FTP_550,
+                "Rename fails: cannot rename data set %s to member %s(%s).",
+                src, dsn, tmember);
+        sess->rnfr_path[0] = '\0';
+        return 0;
+    }
+
+    /* --- member -> member: STOW change, not IDCAMS --------------------- */
+    if (smember[0]) {
+        if (strcmp(src, dsn) != 0) {
+            ftpd_session_reply(sess, FTP_550,
+                "Rename fails: cannot move a member between data sets "
+                "(%s -> %s).", src, dsn);
+            sess->rnfr_path[0] = '\0';
+            return 0;
+        }
+
+        if (check_dataset_access(sess, dsn, RACF_ATTR_ALTER) != 0) {
+            sess->rnfr_path[0] = '\0';
+            return 0;
+        }
+
+        /* __renmem() allocates, opens, STOWs and closes the PDS, so it
+        ** carries its own existence checks — rc 8 for a missing source and
+        ** rc 4 for an occupied target are exactly the two answers __locate()
+        ** could never give here (#92). */
+        ftpd_acee_enter(sess);
+        rc = __renmem(dsn, smember, tmember);
+        ftpd_acee_leave(sess);
+
+        switch (rc) {
+        case 0:
+            ftpd_session_reply(sess, FTP_250, "%s(%s) renamed to %s(%s)",
+                               dsn, smember, dsn, tmember);
+            break;
+        case 4:
+            ftpd_session_reply(sess, FTP_550,
+                "Rename fails: %s(%s) already exists.", dsn, tmember);
+            break;
+        case 8:
+            ftpd_session_reply(sess, FTP_550,
+                "Rename fails: %s(%s) does not exist.", dsn, smember);
+            break;
+        default:
+            ftpd_log(LOG_ERROR, "%s: __renmem(%s,%s,%s) rc=%d",
+                     __func__, dsn, smember, tmember, rc);
+            ftpd_session_reply(sess, FTP_550,
+                "Rename of %s(%s) to %s(%s) failed.",
+                dsn, smember, dsn, tmember);
+            break;
+        }
+
+        sess->rnfr_path[0] = '\0';
+        return 0;
+    }
+
+    /* --- data set -> data set: IDCAMS ALTER ---------------------------- */
 
     /* Check target does not exist */
     memset(&lw, 0, sizeof(lw));
@@ -2094,20 +2229,20 @@ ftpd_mvs_rnto(ftpd_session_t *sess, const char *arg)
 
     /* Rename via IDCAMS ALTER under user's security environment */
     snprintf(cmd, sizeof(cmd),
-             " ALTER '%s' NEWNAME('%s')", sess->rnfr_path, dsn);
+             " ALTER '%s' NEWNAME('%s')", src, dsn);
 
     ftpd_acee_enter(sess);
     rc = idcams(cmd);
     ftpd_acee_leave(sess);
     if (rc != 0) {
         ftpd_session_reply(sess, FTP_550,
-            "Rename of %s to %s failed.", sess->rnfr_path, dsn);
+            "Rename of %s to %s failed.", src, dsn);
         sess->rnfr_path[0] = '\0';
         return 0;
     }
 
     ftpd_session_reply(sess, FTP_250,
-        "%s renamed to %s", sess->rnfr_path, dsn);
+        "%s renamed to %s", src, dsn);
 
     sess->rnfr_path[0] = '\0';
 


### PR DESCRIPTION
Closes #92.

## The defect

Measured on the target with a PDS holding M1, M2, M3:

```
> DELE 'IBMUSER.MBRTEST(M1)'          250 deleted.                  (worked)
> RNFR 'IBMUSER.MBRTEST(M2)'          350 RNFR accepted.
> RNTO 'IBMUSER.MBRTEST(M9)'          550 ... M9 already exists.    (M9 did not)
> RNFR 'IBMUSER.MBRTEST(NOSUCHMB)'    350 RNFR accepted.            (nor did that)
```

One cause behind all of it: **`__locate()` resolves the base data set name and
ignores `(member)`.** RNFR and RNTO kept the member attached and asked LOCATE,
so the "target must not exist" check saw the PDS and rejected every member of
it, the "source must exist" check passed for members that were not there, and
`IDCAMS ALTER` — which renames catalogued data sets, not directory entries —
could not have finished the job in any case.

The same blind spot is why SIZE could not handle members (#88); there it was
`__dscbdv()` that choked on the member form.

## Change

Both handlers split the member off before doing anything else.

* **RNFR** authorizes against the **base** name. A RAKF DATASET profile is held
  under a data set name, so `PDS(MEMBER)` never matched one — only the
  `HLQ == userid` short-circuit was hiding that. Existence is then checked in
  two parts: the data set with `__locate()`, the member with `__listpd()`
  through a new `member_exists()` helper.
* **RNTO** dispatches on what the two names are:
  * member → member in the same PDS: `__renmem()` (`clibio.h:167`), whose STOW
    return codes are exactly the two answers LOCATE could not give — `8` source
    missing, `4` target occupied. Both are mapped to their own 550 text.
  * data set → data set: unchanged, IDCAMS ALTER.
  * member → data set, data set → member, member across two different PDSs:
    550 saying which of the three it was, rather than failing obscurely a few
    steps later.

`member_exists()` reads the directory under the session identity, like LIST
does, so the identity-window discipline from #79 holds — one window, opened and
closed inside the helper, no data set held across it.

## What this does not change

`DELE` of a member keeps using IDCAMS; it works today, and `__stow('D')` would
need an open DCB the delete path does not otherwise have. Noted in #87, which
is where the "replace IDCAMS" idea now ends: its throughput premise was
measured away (0.11s median window), and for **data sets** there is no direct
route — libc370 uses CAMLST only for LOCATE and OBTAIN, both read-only, and the
catalog side would have to handle VSAM user catalogs.

## Verification

Builds clean with `-Wall -Werror`. The behaviour needs the target: after
deploy, the transcript above must become `550 ... does not exist.` for the
missing member on RNFR, and a successful `250 PDS(M2) renamed to PDS(M9)` for
the rename — with the member actually moved in the directory, checked through
the REST API rather than through FTPD's own listing.
