### PR TITLE
Check a data set name before the catalog does (#95)

### DIFF
--- a/doc/FTPD_CONCEPT.md
+++ b/doc/FTPD_CONCEPT.md
@@ -203,16 +203,23 @@ This is lenient behavior for forward compatibility — clients that send z/OS-sp
 - Every resolved name passes `ftpd_dsn_valid()` (`ftpd#dsn.c`) before any
   catalog or allocation work — for every command, not just CWD
 - Allowed: `A-Z`, `0-9`, the national characters `@ # $`, and `-`; `.`
-  separates qualifiers; `*` and `%` only for LIST/NLST patterns
+  separates qualifiers and no qualifier may be empty; the wildcards above only
+  for LIST/NLST patterns
 - Rejected with `501 Invalid data set name "'DSN'".  Use MVS Dsname
   conventions.` — the resolved name is quoted, because what the client sent
   and what FTPD built are rarely the same thing:
   - `put build/x.xmit` → `501 Invalid data set name "'HERC01.BUILD/X.XMIT'". …`
     (previously reached SVC 99 and came back as `550 Cannot allocate dataset`)
-- Not enforced, deliberately: qualifier length (≤ 8), empty qualifiers, and
-  the "must not begin with a digit" rule above. The length rule would turn
-  `ls ABCDEFGHIJ*` — a pattern that matches nothing — into a 501, and MVS 3.8j
-  is more permissive about the first character than the manuals are
+  - `put .profile` → `501 Invalid data set name "'HERC01..PROFILE'". …`
+- A wildcard keeps the qualifier message above, `?` included:
+  `CWD MIK?` → `501 A qualifier in "MIK?" contains an invalid character`.
+  The set lives in `FTPD_DSN_WILDCARDS` (`ftpd#dsn.h`) so the check, the LIST
+  path and the message cannot drift apart. `dsn_match()` implements only `*`,
+  `**` and `%`, so a `?` in a LIST pattern matches nothing
+- Not enforced, deliberately: qualifier length (≤ 8) and the "must not begin
+  with a digit" rule above. The length rule would turn `ls ABCDEFGHIJ*` — a
+  pattern that matches nothing — into a 501, and MVS 3.8j is more permissive
+  about the first character than the manuals are
 - A member (everything from `(`) is not inspected here; `sanitize_member()`
   strips the extension, uppercases and truncates it to 8 characters
 

--- a/doc/FTPD_CONCEPT.md
+++ b/doc/FTPD_CONCEPT.md
@@ -183,6 +183,7 @@ This is lenient behavior for forward compatibility — clients that send z/OS-sp
 - **Quoted** CWD is **absolute** — resets the prefix:
   - `CWD 'SYS1.MACLIB'` → `SYS1.MACLIB.`
 - `CWD ..` / `CDUP` → removes last qualifier. At empty prefix, returns `250` with empty prefix (no error)
+- `CWD .` → changes nothing, answers `250` for the current prefix (or the PDS, in PDS context). Answered before the prefix is built: `HLQ.` + `.` would leave an empty qualifier, and resolving it used to drop PDS context while keeping the PDS as the prefix
 
 **CWD trailing dot controls PDS detection (verified on z/OS 3.1):**
 - **Without** trailing dot → OBTAIN checks DSORG; if PDS → enters PDS context:

--- a/doc/FTPD_CONCEPT.md
+++ b/doc/FTPD_CONCEPT.md
@@ -199,6 +199,23 @@ This is lenient behavior for forward compatibility — clients that send z/OS-sp
 - Only alphanumeric characters, `@`, `#`, `$` allowed in qualifiers
 - Qualifiers must not begin with a digit
 
+**Dataset name character validation (issue #95):**
+- Every resolved name passes `ftpd_dsn_valid()` (`ftpd#dsn.c`) before any
+  catalog or allocation work — for every command, not just CWD
+- Allowed: `A-Z`, `0-9`, the national characters `@ # $`, and `-`; `.`
+  separates qualifiers; `*` and `%` only for LIST/NLST patterns
+- Rejected with `501 Invalid data set name "'DSN'".  Use MVS Dsname
+  conventions.` — the resolved name is quoted, because what the client sent
+  and what FTPD built are rarely the same thing:
+  - `put build/x.xmit` → `501 Invalid data set name "'HERC01.BUILD/X.XMIT'". …`
+    (previously reached SVC 99 and came back as `550 Cannot allocate dataset`)
+- Not enforced, deliberately: qualifier length (≤ 8), empty qualifiers, and
+  the "must not begin with a digit" rule above. The length rule would turn
+  `ls ABCDEFGHIJ*` — a pattern that matches nothing — into a 501, and MVS 3.8j
+  is more permissive about the first character than the manuals are
+- A member (everything from `(`) is not inspected here; `sanitize_member()`
+  strips the extension, uppercases and truncates it to 8 characters
+
 **Supported Dataset Organizations:**
 - PS (Physical Sequential)
 - PO (Partitioned — PDS)

--- a/include/ftpd#dsn.h
+++ b/include/ftpd#dsn.h
@@ -1,0 +1,46 @@
+#ifndef FTPD_DSN_H
+#define FTPD_DSN_H
+/*
+** FTPD Data Set Name Validation
+**
+** One question, asked before a name reaches the catalog: is this a data set
+** name at all?  It used to be asked by nobody -- a client that sent its local
+** path as the remote name (`put build/ftpd.deploy.xmit`) had it turned into
+** HERC01.BUILD/FTPD.DEPLOY.XMIT, and the '/' was only noticed by SVC 99,
+** which reported an allocation failure for a name that was never allocatable
+** (issue #95).
+**
+** Free of project and MVS headers on purpose: this is the piece of the name
+** handling that a host unit test can link (test/tstdsn.c).
+*/
+
+/*
+** Is dsn a syntactically valid MVS data set name?
+**
+** Checked: every character.  Qualifiers are separated by '.' and may hold
+** A-Z, 0-9, the national characters @ # $, and the hyphen '-'.  The name is
+** expected to be uppercase already -- resolve_dsn() uppercases before asking,
+** and a lowercase letter in a name that reached this point is a bug worth
+** hearing about rather than a name to fix up silently.
+**
+** A member -- everything from the first '(' -- is not looked at.  Member
+** names are sanitized on their own path (sanitize_member() in ftpd#mvs.c),
+** and the callers still hold the combined DSN(MEMBER) form when they ask.
+**
+** Deliberately NOT checked, so that names MVS accepts today keep working:
+** qualifier length (<= 8), empty qualifiers, and the rule that a qualifier
+** begins with an alphabetic or national character.  The length rule would
+** turn `ls ABCDEFGHIJ*` -- a pattern that simply matches nothing -- into a
+** 501, and MVS 3.8j is more permissive about the first character than the
+** manuals are.  Both are separate decisions; see issue #95.
+**
+** allow_wildcards -- when nonzero, '*' and '%' are accepted as ordinary
+**                    characters.  LIST and NLST resolve patterns, every
+**                    other command resolves one name.
+**
+** Returns 1 when the name is valid, 0 when it is not.  A NULL or empty name
+** is not valid.
+*/
+int ftpd_dsn_valid(const char *dsn, int allow_wildcards)     asm("FTPDSNVL");
+
+#endif /* FTPD_DSN_H */

--- a/include/ftpd#dsn.h
+++ b/include/ftpd#dsn.h
@@ -15,28 +15,40 @@
 */
 
 /*
+** The characters that make a name a pattern rather than a name.  Shared so
+** that the check, the LIST path and the message that names the offending
+** qualifier cannot drift apart.  '?' is here because FTPD has always
+** documented and rejected it alongside '*' and '%' -- the matcher itself
+** (dsn_match(), ftpd#mvs.c) implements only '*', '**' and '%', so a '?' in a
+** LIST pattern matches nothing.
+*/
+#define FTPD_DSN_WILDCARDS  "*%?"
+
+/*
 ** Is dsn a syntactically valid MVS data set name?
 **
-** Checked: every character.  Qualifiers are separated by '.' and may hold
-** A-Z, 0-9, the national characters @ # $, and the hyphen '-'.  The name is
-** expected to be uppercase already -- resolve_dsn() uppercases before asking,
-** and a lowercase letter in a name that reached this point is a bug worth
-** hearing about rather than a name to fix up silently.
+** Checked: every character, and that no qualifier is empty.  Qualifiers are
+** separated by '.' and may hold A-Z, 0-9, the national characters @ # $, and
+** the hyphen '-'.  The name is expected to be uppercase already --
+** resolve_dsn() uppercases before asking, and a lowercase letter in a name
+** that reached this point is a bug worth hearing about rather than a name to
+** fix up silently.  A trailing dot counts as an empty qualifier; resolve_dsn()
+** strips it before asking, because there it means "prefix only".
 **
 ** A member -- everything from the first '(' -- is not looked at.  Member
 ** names are sanitized on their own path (sanitize_member() in ftpd#mvs.c),
 ** and the callers still hold the combined DSN(MEMBER) form when they ask.
 **
 ** Deliberately NOT checked, so that names MVS accepts today keep working:
-** qualifier length (<= 8), empty qualifiers, and the rule that a qualifier
-** begins with an alphabetic or national character.  The length rule would
-** turn `ls ABCDEFGHIJ*` -- a pattern that simply matches nothing -- into a
-** 501, and MVS 3.8j is more permissive about the first character than the
-** manuals are.  Both are separate decisions; see issue #95.
+** qualifier length (<= 8) and the rule that a qualifier begins with an
+** alphabetic or national character.  The length rule would turn
+** `ls ABCDEFGHIJ*` -- a pattern that simply matches nothing -- into a 501,
+** and MVS 3.8j is more permissive about the first character than the manuals
+** are.  Both are separate decisions; see issue #95.
 **
-** allow_wildcards -- when nonzero, '*' and '%' are accepted as ordinary
-**                    characters.  LIST and NLST resolve patterns, every
-**                    other command resolves one name.
+** allow_wildcards -- when nonzero, FTPD_DSN_WILDCARDS are accepted as
+**                    ordinary characters.  LIST and NLST resolve patterns,
+**                    every other command resolves one name.
 **
 ** Returns 1 when the name is valid, 0 when it is not.  A NULL or empty name
 ** is not valid.

--- a/project.toml
+++ b/project.toml
@@ -27,6 +27,12 @@ ac = 1                    # APF authorization (SETCODE AC(1));
 name = "TSTADR"
 sources = ["test/tstadr.c", "src/ftpd#adr.c"]
 
+# ftpd_dsn_valid() -- the data set name character check (#95).  Same shape as
+# TSTADR: ftpd#dsn.c is free of ftpd.h and of MVS services, so this is DUAL.
+[[test]]
+name = "TSTDSN"
+sources = ["test/tstdsn.c", "src/ftpd#dsn.c"]
+
 # ── Dependencies ─────────────────────────────────────────
 # Only ufsd remains a real dependency: libufs.h / libufs.a are ufsd-specific.
 # crent370 was dropped -- every crent370 header ftpd uses (clib*.h, racf.h,

--- a/src/ftpd#dsn.c
+++ b/src/ftpd#dsn.c
@@ -1,0 +1,42 @@
+/*
+** FTPD Data Set Name Validation
+**
+** See include/ftpd#dsn.h.  The set of legal characters is spelled out as a
+** string and searched, rather than tested with ranges: A-Z is not contiguous
+** in EBCDIC (C1-C9, D1-D9, E2-E9), so `c >= 'A' && c <= 'Z'` would accept the
+** bytes in the gaps -- 0xCA-0xCF, 0xDA-0xDF -- plus '\' (0xE0), '{' (0xC0)
+** and '}' (0xD0).  The table costs 41 bytes and is right in both encodings.
+*/
+#include <string.h>
+
+#include "ftpd#dsn.h"
+
+/* Every character an MVS data set name qualifier may hold.  The '.' that
+** separates qualifiers and the wildcards are handled separately below. */
+static const char dsn_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$-";
+
+/* --------------------------------------------------------------------
+** Validate a data set name.  See ftpd#dsn.h for the contract.
+** ----------------------------------------------------------------- */
+int
+ftpd_dsn_valid(const char *dsn, int allow_wildcards)
+{
+    const char *p;
+
+    if (!dsn || !dsn[0])
+        return 0;
+
+    for (p = dsn; *p && *p != '('; p++) {
+        if (*p == '.')
+            continue;
+
+        if (allow_wildcards && (*p == '*' || *p == '%'))
+            continue;
+
+        if (strchr(dsn_chars, *p) == NULL)
+            return 0;
+    }
+
+    /* A name that is nothing but a member -- "(MEM)" -- is not a name. */
+    return (p != dsn);
+}

--- a/src/ftpd#dsn.c
+++ b/src/ftpd#dsn.c
@@ -22,21 +22,34 @@ int
 ftpd_dsn_valid(const char *dsn, int allow_wildcards)
 {
     const char *p;
+    int qlen;               /* characters in the qualifier being read */
 
-    if (!dsn || !dsn[0])
+    if (!dsn)
         return 0;
 
+    qlen = 0;
     for (p = dsn; *p && *p != '('; p++) {
-        if (*p == '.')
+        if (*p == '.') {
+            /* Nothing between two dots is not a qualifier.  `put .profile`
+            ** resolved to HERC01..PROFILE and got as far as SVC 99. */
+            if (qlen == 0)
+                return 0;
+            qlen = 0;
             continue;
+        }
 
-        if (allow_wildcards && (*p == '*' || *p == '%'))
+        if (allow_wildcards && strchr(FTPD_DSN_WILDCARDS, *p) != NULL) {
+            qlen++;
             continue;
+        }
 
         if (strchr(dsn_chars, *p) == NULL)
             return 0;
+
+        qlen++;
     }
 
-    /* A name that is nothing but a member -- "(MEM)" -- is not a name. */
-    return (p != dsn);
+    /* qlen is the last qualifier's length: 0 means the name ended on a dot,
+    ** was empty, or was nothing but a member -- "(MEM)". */
+    return (qlen > 0);
 }

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -416,7 +416,7 @@ ftpd_mvs_cdup(ftpd_session_t *sess)
 ** z/OS behavior:
 ** - CWD sets prefix only, no existence check (always 250)
 ** - Exception: if resolved name is a PDS, response says so
-** - CWD .. is treated as CDUP
+** - CWD .. is treated as CDUP, CWD . changes nothing
 ** ----------------------------------------------------------------- */
 int
 ftpd_mvs_cwd(ftpd_session_t *sess, const char *arg)
@@ -429,6 +429,26 @@ ftpd_mvs_cwd(ftpd_session_t *sess, const char *arg)
     /* CWD .. / CWD handled as CDUP */
     if (arg && strcmp(arg, "..") == 0)
         return ftpd_mvs_cdup(sess);
+
+    /* CWD . means stay here, and has to be answered before the prefix is
+    ** built: "HLQ." + "." is "HLQ..", one trailing dot comes off again, and
+    ** the empty qualifier that remains would answer 501 for what every
+    ** client sends as a no-op (#95).
+    **
+    ** It also has to be a real no-op.  Resolving it used to clear the PDS
+    ** context while keeping the PDS as the prefix, which left a session
+    ** where `put x` addressed the data set HLQ.PDS.X. */
+    if (arg && strcmp(arg, ".") == 0) {
+        if (sess->in_pds)
+            ftpd_session_reply(sess, FTP_250,
+                "The working directory \"%s\" is a partitioned data set",
+                sess->pds_name);
+        else
+            ftpd_session_reply(sess, FTP_250,
+                "\"%s\" is the working directory name prefix.",
+                sess->mvs_cwd);
+        return 0;
+    }
 
     /* Detect trailing dot BEFORE resolve_dsn strips it.
     ** z/OS behavior (verified on z/OS 3.1):

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -11,6 +11,7 @@
 #include "ftpd#ses.h"
 #include "ftpd#aut.h"
 #include "ftpd#dat.h"
+#include "ftpd#dsn.h"
 #include "ftpd#mvs.h"
 #include "ftpd#xlt.h"
 #include "mvssupa.h"
@@ -166,7 +167,11 @@ sanitize_member(const char *in, char *out, int outsz)
 **   DSN.NAME    → relative: prepend mvs_cwd prefix
 **
 ** Result is uppercased and null-terminated in buf (max 44 chars).
-** Returns 0 on success, -1 if name is too long or contains wildcards.
+**
+** Returns 0 on success, or, with the reply left to dsn_error():
+**   -1  the name is too long
+**   -2  the name holds a wildcard and the caller resolves one name
+**   -3  the name holds a character a data set name may not hold
 ** ----------------------------------------------------------------- */
 static int
 resolve_dsn(ftpd_session_t *sess, const char *arg, char *buf, int bufsz,
@@ -236,6 +241,14 @@ resolve_dsn(ftpd_session_t *sess, const char *arg, char *buf, int bufsz,
     len = strlen(buf);
     if (len > 0 && buf[len - 1] == '.')
         buf[len - 1] = '\0';
+
+    /* Ask last, with the name in the form the rest of FTPD will use it:
+    ** a client that sends its local path as the remote name (`put
+    ** build/x.xmit`) used to get that '/' carried through LOCATE and into
+    ** SVC 99, which reported an allocation failure for a name that was
+    ** never allocatable (#95). */
+    if (!ftpd_dsn_valid(buf, allow_wildcards))
+        return -3;
 
     return 0;
 }
@@ -317,6 +330,38 @@ found:
 }
 
 /* --------------------------------------------------------------------
+** Helper: reply to a resolve_dsn() failure.
+**
+** Every command resolves a name the same way and used to answer the same
+** single "Invalid dataset name" for every way it can go wrong.  Saying
+** which one it was is worth more than the sentence: a wildcard names the
+** qualifier that carries it, and an unusable character comes back with the
+** name FTPD actually built, which is the surprising part when the client
+** sent a path and got a data set name (#95).
+**
+** arg -- the argument as the client sent it, for the wildcard message.
+** dsn -- the resolved name; read only for -3, where resolve_dsn() has
+**        filled it in completely.
+** ----------------------------------------------------------------- */
+static void
+dsn_error(ftpd_session_t *sess, const char *arg, const char *dsn, int rc)
+{
+    if (rc == -2) {
+        wildcard_error(sess, arg);
+        return;
+    }
+
+    if (rc == -3) {
+        ftpd_session_reply(sess, FTP_501,
+            "Invalid data set name \"'%s'\".  Use MVS Dsname conventions.",
+            dsn);
+        return;
+    }
+
+    ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+}
+
+/* --------------------------------------------------------------------
 ** CDUP — remove last qualifier from CWD
 ** SYS1.MACLIB. → SYS1.
 ** SYS1. → (empty, reset to HLQ)
@@ -388,12 +433,8 @@ ftpd_mvs_cwd(ftpd_session_t *sess, const char *arg)
     }
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
-    if (rc == -2) {
-        wildcard_error(sess, arg);
-        return 0;
-    }
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -823,9 +864,9 @@ ftpd_mvs_list(ftpd_session_t *sess, const char *arg, int nlst)
         if (strcmp(arg, "*") == 0) {
             strcpy(prefix, cwd_notrail);
         } else {
-            if (resolve_dsn(sess, arg, prefix, sizeof(prefix), 1) != 0) {
-                ftpd_session_reply(sess, FTP_501,
-                                   "Invalid dataset name");
+            int rc = resolve_dsn(sess, arg, prefix, sizeof(prefix), 1);
+            if (rc != 0) {
+                dsn_error(sess, arg, prefix, rc);
                 return 0;
             }
         }
@@ -1171,7 +1212,7 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -1601,7 +1642,7 @@ ftpd_mvs_stor(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -1928,7 +1969,7 @@ ftpd_mvs_dele(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -1995,7 +2036,7 @@ ftpd_mvs_mkd(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -2048,7 +2089,7 @@ ftpd_mvs_rmd(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -2102,7 +2143,7 @@ ftpd_mvs_rnfr(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 
@@ -2170,7 +2211,7 @@ ftpd_mvs_rnto(ftpd_session_t *sess, const char *arg)
 
     rc = resolve_dsn(sess, arg, dsn, sizeof(dsn), 0);
     if (rc != 0) {
-        ftpd_session_reply(sess, FTP_501, "Invalid dataset name");
+        dsn_error(sess, arg, dsn, rc);
         return 0;
     }
 

--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -188,8 +188,11 @@ resolve_dsn(ftpd_session_t *sess, const char *arg, char *buf, int bufsz,
         return 0;
     }
 
-    /* Reject wildcards unless explicitly allowed (LIST/NLST) */
-    if (!allow_wildcards && (strchr(arg, '*') || strchr(arg, '%'))) {
+    /* Reject wildcards unless explicitly allowed (LIST/NLST).  Asked of the
+    ** raw argument rather than of the resolved name, because the PDS member
+    ** branch below returns before the name is validated -- and a member is
+    ** not a pattern either. */
+    if (!allow_wildcards && strpbrk(arg, FTPD_DSN_WILDCARDS) != NULL) {
         return -2;
     }
 
@@ -257,6 +260,16 @@ resolve_dsn(ftpd_session_t *sess, const char *arg, char *buf, int bufsz,
 ** CWD — change working directory (MVS dataset prefix)
 ** ----------------------------------------------------------------- */
 /* --------------------------------------------------------------------
+** Helper: is c one of the characters that make a name a pattern?
+** Guards against '\0', which strchr() would report as a member of any set.
+** ----------------------------------------------------------------- */
+static int
+is_wildcard(char c)
+{
+    return c != '\0' && strchr(FTPD_DSN_WILDCARDS, c) != NULL;
+}
+
+/* --------------------------------------------------------------------
 ** Helper: generate z/OS-compatible wildcard error message.
 ** Identifies the problematic qualifier and says "begins with"
 ** or "contains" depending on position.
@@ -283,7 +296,7 @@ wildcard_error(ftpd_session_t *sess, const char *arg)
             /* Check if this qualifier had a wildcard */
             wc = qstart;
             while (wc < p) {
-                if (*wc == '*' || *wc == '%')
+                if (is_wildcard(*wc))
                     goto found;
                 wc++;
             }
@@ -294,7 +307,7 @@ wildcard_error(ftpd_session_t *sess, const char *arg)
     /* Check last qualifier */
     wc = qstart;
     while (*wc) {
-        if (*wc == '*' || *wc == '%')
+        if (is_wildcard(*wc))
             goto found;
         wc++;
     }
@@ -314,7 +327,7 @@ found:
     if (qstart == arg || (arg[0] == '\'' && qstart == arg + 1) ||
         *(qstart - 1) == '.') {
         /* First char of qualifier is the wildcard? */
-        if (*qstart == '*' || *qstart == '%') {
+        if (is_wildcard(*qstart)) {
             ftpd_session_reply(sess, FTP_501,
                 "A qualifier in \"%s\" begins with an invalid character",
                 qual);

--- a/test/tstdsn.c
+++ b/test/tstdsn.c
@@ -61,8 +61,17 @@ main(void)
     CHECK(bad("HERC01.TEST:1"), "a colon is rejected");
     CHECK(bad("HERC01.TEST+1"), "a plus sign is rejected");
     CHECK(bad("HERC01.TEST_1"), "an underscore is rejected");
-    CHECK(bad("HERC01.TEST?"), "a question mark is rejected");
     CHECK(bad("HERC01.TEST\t"), "a control character is rejected");
+
+    /* --- a qualifier has to hold something ---------------------------- */
+    CHECK(bad("HERC01..PROFILE"),
+          "an empty qualifier is rejected (`put .profile` reached SVC 99)");
+    CHECK(bad(".PROFILE"), "a leading dot is an empty first qualifier");
+    CHECK(bad("HERC01."),
+          "a trailing dot is an empty last qualifier -- resolve_dsn strips it "
+          "first, where it means prefix-only");
+    CHECK(bad("."), "a lone dot is not a name");
+    CHECK(bad("HERC01...TEST"), "two empty qualifiers are rejected");
 
     /* --- letters are not a range -------------------------------------- */
     /* In EBCDIC A-Z runs C1-C9, D1-D9, E2-E9 with gaps, and '{' (C0),
@@ -85,13 +94,20 @@ main(void)
     CHECK(bad("(MEM)"), "a member without a data set is not a name");
 
     /* --- wildcards belong to LIST and NLST ---------------------------- */
+    /* '?' is one of them: FTPD has always documented and rejected it with
+    ** '*' and '%' (FTPD_CONCEPT.md), and dsn_match() ignoring it means a
+    ** pattern carrying one matches nothing -- not that it is a letter. */
     CHECK(bad("HERC01.MIK*"), "'*' is rejected when patterns are not allowed");
     CHECK(bad("HERC01.%BC"), "'%' is rejected when patterns are not allowed");
+    CHECK(bad("HERC01.MIK?"), "'?' is rejected when patterns are not allowed");
     CHECK(ftpd_dsn_valid("HERC01.MIK*", 1) == 1, "'*' is a pattern for LIST");
     CHECK(ftpd_dsn_valid("HERC01.%BC", 1) == 1, "'%' is a pattern for LIST");
+    CHECK(ftpd_dsn_valid("HERC01.MIK?", 1) == 1, "'?' is a pattern for LIST");
     CHECK(ftpd_dsn_valid("HERC01.*", 1) == 1, "a whole qualifier may be a pattern");
     CHECK(ftpd_dsn_valid("HERC01.BUILD/X", 1) == 0,
           "allowing patterns does not allow anything else");
+    CHECK(ftpd_dsn_valid("HERC01..*", 1) == 0,
+          "allowing patterns does not allow an empty qualifier");
 
     /* --- nothing is not a name ---------------------------------------- */
     CHECK(bad(""), "an empty name is rejected");

--- a/test/tstdsn.c
+++ b/test/tstdsn.c
@@ -1,0 +1,102 @@
+/* TSTDSN.C
+** Tests for ftpd_dsn_valid() -- the character check every data set name now
+** passes through before it reaches the catalog (issue #95).
+**
+** The regression that started it: `put build/ftpd.deploy.xmit` sends the
+** local path as the remote name.  resolve_dsn() prepended the CWD prefix and
+** uppercased, nothing looked at the '/', and the resulting
+** HERC01.BUILD/FTPD.DEPLOY.XMIT was carried all the way to SVC 99 -- which
+** answered "550 Cannot allocate dataset", blaming allocation for a name that
+** was never a name.  The cases below pin down what a name may hold, and the
+** two that must keep working alongside it: PDS members and LIST wildcards.
+**
+** ftpd#dsn.c is free of project and MVS headers, so this is a DUAL test: it
+** runs natively via `make test-host` and on MVS via `make test-mvs`.  The
+** EBCDIC cases below only mean something in the second run -- see the
+** "letters are not a range" section.
+*/
+#include <stdio.h>
+
+#include "ftpd#dsn.h"
+#include <mbtcheck.h>
+
+/* Valid as an ordinary name -- i.e. with wildcards not allowed. */
+static int
+ok(const char *dsn)
+{
+    return ftpd_dsn_valid(dsn, 0) == 1;
+}
+
+/* Rejected as an ordinary name. */
+static int
+bad(const char *dsn)
+{
+    return ftpd_dsn_valid(dsn, 0) == 0;
+}
+
+int
+main(void)
+{
+    printf("=== FTPD data set name validation tests (#95) ===\n");
+
+    /* --- the reported bug -------------------------------------------- */
+    CHECK(bad("HERC01.BUILD/FTPD.DEPLOY.XMIT"),
+          "a path in the name is rejected (was 550 Cannot allocate)");
+    CHECK(bad("HERC01.BUILD/X"), "a '/' anywhere in the name is rejected");
+    CHECK(bad("/U/HERC01/FILE"), "a UFS path is not a data set name");
+
+    /* --- what a name may hold ----------------------------------------- */
+    CHECK(ok("HERC01.FTPD.DEPLOY.XMIT"), "the name the client should send");
+    CHECK(ok("SYS1.MACLIB"), "a two qualifier name");
+    CHECK(ok("A"), "a single character name");
+    CHECK(ok("HERC01.TEST1.V2R3"), "digits inside a qualifier");
+    CHECK(ok("HERC01.@#$"), "the national characters @ # $");
+    CHECK(ok("HERC01.MY-DATA"), "a hyphen");
+    CHECK(ok("HERC01.GDG.G0001V00"), "a GDG generation data set");
+
+    /* --- what a name may not hold ------------------------------------- */
+    CHECK(bad("HERC01.MY DATA"), "a blank is rejected");
+    CHECK(bad("HERC01.MY,DATA"), "a comma is rejected");
+    CHECK(bad("'HERC01.TEST'"), "quotes are rejected -- resolve_dsn strips them");
+    CHECK(bad("HERC01.TEST:1"), "a colon is rejected");
+    CHECK(bad("HERC01.TEST+1"), "a plus sign is rejected");
+    CHECK(bad("HERC01.TEST_1"), "an underscore is rejected");
+    CHECK(bad("HERC01.TEST?"), "a question mark is rejected");
+    CHECK(bad("HERC01.TEST\t"), "a control character is rejected");
+
+    /* --- letters are not a range -------------------------------------- */
+    /* In EBCDIC A-Z runs C1-C9, D1-D9, E2-E9 with gaps, and '{' (C0),
+    ** '}' (D0) and '\' (E0) sit inside what a range test would call a
+    ** letter.  On MVS these three are the ones a `c >= 'A' && c <= 'Z'`
+    ** check would wave through; here they must be rejected. */
+    CHECK(bad("HERC01.TEST{"), "'{' is rejected (a letter to an EBCDIC range test)");
+    CHECK(bad("HERC01.TEST}"), "'}' is rejected (a letter to an EBCDIC range test)");
+    CHECK(bad("HERC01.TEST\\"), "'\\' is rejected (a letter to an EBCDIC range test)");
+
+    /* --- the name arrives uppercase ----------------------------------- */
+    CHECK(bad("herc01.test"), "lowercase is rejected -- the caller uppercases first");
+    CHECK(bad("HERC01.Test"), "a single lowercase letter is rejected");
+
+    /* --- members are somebody else's business ------------------------- */
+    CHECK(ok("HERC01.PDS(MEM)"), "a member reference is valid -- and not inspected");
+    CHECK(ok("HERC01.PDS(mem.ext)"),
+          "what sanitize_member() still has to clean up is not rejected here");
+    CHECK(bad("HERC01.P/DS(MEM)"), "the data set part of a member reference is checked");
+    CHECK(bad("(MEM)"), "a member without a data set is not a name");
+
+    /* --- wildcards belong to LIST and NLST ---------------------------- */
+    CHECK(bad("HERC01.MIK*"), "'*' is rejected when patterns are not allowed");
+    CHECK(bad("HERC01.%BC"), "'%' is rejected when patterns are not allowed");
+    CHECK(ftpd_dsn_valid("HERC01.MIK*", 1) == 1, "'*' is a pattern for LIST");
+    CHECK(ftpd_dsn_valid("HERC01.%BC", 1) == 1, "'%' is a pattern for LIST");
+    CHECK(ftpd_dsn_valid("HERC01.*", 1) == 1, "a whole qualifier may be a pattern");
+    CHECK(ftpd_dsn_valid("HERC01.BUILD/X", 1) == 0,
+          "allowing patterns does not allow anything else");
+
+    /* --- nothing is not a name ---------------------------------------- */
+    CHECK(bad(""), "an empty name is rejected");
+    CHECK(ftpd_dsn_valid(NULL, 0) == 0, "a NULL name is rejected");
+    CHECK(ftpd_dsn_valid(NULL, 1) == 0, "a NULL name is rejected for LIST too");
+
+    return mbt_test_summary("TSTDSN");
+}


### PR DESCRIPTION
Closes #95.

`put build/ftpd.deploy.xmit` sends the local path as the remote name. `resolve_dsn()` prepended the CWD prefix and uppercased it but checked no characters, so `HERC01.BUILD/FTPD.DEPLOY.XMIT` passed the RACF check, missed in LOCATE and died in SVC 99 — reported as `550 Cannot allocate dataset`, blaming allocation for a name that was never allocatable.

## What changed

- **`ftpd_dsn_valid()`** (new `src/ftpd#dsn.c` / `include/ftpd#dsn.h`) checks every character before any catalog or allocation work: `A-Z`, `0-9`, the national characters `@ # $`, the hyphen, `.` as qualifier separator with no qualifier empty, and the wildcards only where LIST and NLST resolve patterns.
- **The reply** is the one z/OS gives and `doc/ZOS_FTP_REFERENCE.md:1055` already documented, quoting the *resolved* name — what the client sent and what FTPD built are rarely the same thing:
  ```
  501 Invalid data set name "'HERC01.BUILD/FTPD.DEPLOY.XMIT'".  Use MVS Dsname conventions.
  ```
- **`dsn_error()`** replaces the nine call sites that all answered the same `Invalid dataset name` for every way a name can fail to resolve. Wildcards keep the qualifier-naming message, an unusable character gets the new one.
- **`?` is a wildcard everywhere.** It was being rejected by the character check with the general message while `*` and `%` got the qualifier message `FTPD_CONCEPT.md:196` documents as verified on z/OS 3.1 — for the same mistake. The set now lives in `FTPD_DSN_WILDCARDS` so the rejection, the message and the LIST path cannot drift apart:
  ```
  CWD MIK?  ->  501 A qualifier in "MIK?" contains an invalid character
  ```
  LIST is unchanged: `dsn_match()` implements only `*`, `**` and `%`, so a pattern carrying a `?` matches nothing, as before. The wildcard check stays on the raw argument rather than the resolved name — the PDS member branch of `resolve_dsn()` returns before validation, and `RETR MEM?` inside a PDS used to build a member name with a `?` in it.
- **Empty qualifiers are rejected.** `put .profile` resolved to `HERC01..PROFILE` and reached SVC 99 for the same reason the reported bug did. Covers a leading dot and a trailing one too; `resolve_dsn()` strips a trailing dot before asking, where it means prefix-only.

## Deliberate non-changes

- **Members are untouched.** Validation stops at the first `(`; `sanitize_member()` keeps doing the rest, and the `in_pds` branch of `resolve_dsn()` still strips a leading path — so `put build/x.xmit` *into* a PDS works exactly as before.
- **Qualifier length (≤ 8) and "must begin with a letter" stay unchecked.** The length rule would turn `ls ABCDEFGHIJ*` — a pattern that simply matches nothing — into a 501, and MVS 3.8j is more permissive about the first character than the manuals are. Separate decisions.
- **A table searched with `strchr()`, not a range test.** `c >= 'A' && c <= 'Z'` is wrong in EBCDIC: A-Z runs C1-C9/D1-D9/E2-E9, so a range test accepts the gap bytes plus `\` (E0), `{` (C0) and `}` (D0). TSTDSN pins those three down; the assertion only means something in the `test-mvs` run.

## Testing

`make test-host`: TSTDSN, 43 assertions, all pass (TSTADR unchanged at 29). `ftpd#dsn.c` is free of project and MVS headers, so the test is DUAL and also runs under `make test-mvs`.

The unit test covers `ftpd_dsn_valid()` itself. The end-to-end path — `resolve_dsn()` returning -2/-3, `dsn_error()` formatting the reply, STOR answering 501 — is verified by reading the code, not by a test; confirming it on the target is one `put build/ftpd.deploy.xmit` after deploy.

https://claude.ai/code/session_01Acc7qm2TkDpFjsyhwunKJk