### PR TITLE
Notice when a control-connection write fails

### DIFF
--- a/include/ftpd#ses.h
+++ b/include/ftpd#ses.h
@@ -16,6 +16,7 @@ struct ftpd_session {
 
     /* Sockets */
     int             ctrl_sock;      /* control connection socket     */
+    int             ctrl_dead;      /* 1 = control write failed      */
     int             data_sock;      /* data connection socket        */
     int             pasv_sock;      /* passive listen socket         */
 
@@ -124,19 +125,31 @@ int ftpd_session_run(void *udata, CTHDWORK *work)           asm("FTPSESRN");
 void ftpd_session_free(ftpd_session_t *sess)                asm("FTPSESFR");
 
 /*
+** Write raw bytes to the control connection.  The buffer must already
+** be in ASCII.  Short writes are completed; any failure closes the
+** session (see ftpd_session_reply()).
+** Returns 0 when everything was written, -1 otherwise.
+*/
+int ftpd_session_send(ftpd_session_t *sess,
+                      const char *buf, int len)             asm("FTPSESSD");
+
+/*
 ** Send an FTP reply on the control connection.
 ** Message is in EBCDIC internally, translated to ASCII before sending.
+** A failed write marks the session closing; callers that ignore the
+** return value still terminate, because the command loop tests state.
+** Returns 0 when the reply was written, -1 otherwise.
 */
-void ftpd_session_reply(ftpd_session_t *sess, int code,
-                        const char *fmt, ...)               asm("FTPSESRP");
+int ftpd_session_reply(ftpd_session_t *sess, int code,
+                       const char *fmt, ...)                asm("FTPSESRP");
 
 /*
 ** Send a multi-line FTP reply.
 ** First line uses "code-" prefix, last line uses "code " prefix.
 */
-void ftpd_session_reply_multi(ftpd_session_t *sess, int code,
-                              const char *first,
-                              const char *last)             asm("FTPSESRM");
+int ftpd_session_reply_multi(ftpd_session_t *sess, int code,
+                             const char *first,
+                             const char *last)              asm("FTPSESRM");
 
 /*
 ** Read one command line from the control connection.

--- a/src/ftpd#cmd.c
+++ b/src/ftpd#cmd.c
@@ -90,8 +90,7 @@ cmd_feat(ftpd_session_t *sess)
         sess->server->config.sslproxy ? " PBSZ\r\n PROT\r\n" : "");
     for (i = 0; i < len; i++)
         buf[i] = ebc2asc[(unsigned char)buf[i]];
-    send(sess->ctrl_sock, buf, len, 0);
-    return 0;
+    return ftpd_session_send(sess, buf, len);
 }
 
 /* --------------------------------------------------------------------

--- a/src/ftpd#dat.c
+++ b/src/ftpd#dat.c
@@ -319,7 +319,12 @@ ftpd_data_send(ftpd_session_t *sess, const void *buf, int len)
     while (sent < len) {
         rc = send(sess->data_sock, (const char *)buf + sent, len - sent, 0);
         if (rc <= 0) {
-            ftpd_log(LOG_ERROR, "%s: send failed, errno=%d", __func__, errno);
+            /* errno only carries a diagnosis when send() itself failed;
+            ** for any other non-positive return it is a leftover from an
+            ** earlier call and reads like a real cause. */
+            ftpd_log(LOG_ERROR, "%s: send failed after %d of %d bytes, "
+                     "rc=%d, errno=%d", __func__, sent, len, rc,
+                     (rc < 0) ? errno : 0);
             return -1;
         }
         sent += rc;

--- a/src/ftpd#ses.c
+++ b/src/ftpd#ses.c
@@ -87,15 +87,59 @@ ftpd_session_free(ftpd_session_t *sess)
 }
 
 /* --------------------------------------------------------------------
+** Write raw bytes to the control connection.
+**
+** Every reply funnels through here so a failed write is noticed once,
+** centrally, instead of at ~200 call sites: the session is marked
+** closing, and the command loop ends on its next iteration.  Callers
+** may ignore the return value and still terminate correctly.
+**
+** No retry and no interpretation of transport-level codes happens here.
+** On a blocking socket -- which the control connection is, FIONBIO is
+** set only on the listener -- waiting out a full send buffer is the C
+** library's job (libc370 issue #120).  Anything negative that reaches
+** us means the peer is gone.
+** ----------------------------------------------------------------- */
+int
+ftpd_session_send(ftpd_session_t *sess, const char *buf, int len)
+{
+    int sent = 0;
+    int rc;
+
+    if (sess->ctrl_dead)
+        return -1;
+
+    while (sent < len) {
+        rc = send(sess->ctrl_sock, buf + sent, len - sent, 0);
+        if (rc <= 0) {
+            /* Report once per session: a dead control connection
+            ** otherwise produces one message per queued reply. */
+            ftpd_log(LOG_INFO,
+                     "%s: control write failed after %d of %d bytes, "
+                     "socket %d, rc=%d, errno=%d -- closing session",
+                     __func__, sent, len, sess->ctrl_sock, rc,
+                     (rc < 0) ? errno : 0);
+            sess->ctrl_dead = 1;
+            sess->state = SESS_CLOSING;
+            return -1;
+        }
+        sent += rc;
+    }
+
+    return 0;
+}
+
+/* --------------------------------------------------------------------
 ** Send FTP reply on control connection (EBCDIC -> ASCII)
 ** ----------------------------------------------------------------- */
-void
+int
 ftpd_session_reply(ftpd_session_t *sess, int code, const char *fmt, ...)
 {
     char buf[512];
     va_list ap;
     int len;
     int i;
+    int rc;
 
     /* Format: "code message\r\n" */
     len = snprintf(buf, sizeof(buf) - 2, "%d ", code);
@@ -112,15 +156,20 @@ ftpd_session_reply(ftpd_session_t *sess, int code, const char *fmt, ...)
     for (i = 0; i < len; i++)
         buf[i] = ebc2asc[(unsigned char)buf[i]];
 
-    send(sess->ctrl_sock, buf, len, 0);
+    rc = ftpd_session_send(sess, buf, len);
 
-    ftpd_trace(">>> %d %.*s", code, len - 2, buf + 4);
+    /* Trace what actually went out -- a reply that never reached the
+    ** client must not appear in the trace as if it had. */
+    if (rc == 0)
+        ftpd_trace(">>> %d %.*s", code, len - 2, buf + 4);
+
+    return rc;
 }
 
 /* --------------------------------------------------------------------
 ** Send multi-line FTP reply
 ** ----------------------------------------------------------------- */
-void
+int
 ftpd_session_reply_multi(ftpd_session_t *sess, int code,
                          const char *first, const char *last)
 {
@@ -132,13 +181,14 @@ ftpd_session_reply_multi(ftpd_session_t *sess, int code,
     len = snprintf(buf, sizeof(buf) - 2, "%d-%s\r\n", code, first);
     for (i = 0; i < len; i++)
         buf[i] = ebc2asc[(unsigned char)buf[i]];
-    send(sess->ctrl_sock, buf, len, 0);
+    if (ftpd_session_send(sess, buf, len) < 0)
+        return -1;
 
     /* Last line: "code text\r\n" */
     len = snprintf(buf, sizeof(buf) - 2, "%d %s\r\n", code, last);
     for (i = 0; i < len; i++)
         buf[i] = ebc2asc[(unsigned char)buf[i]];
-    send(sess->ctrl_sock, buf, len, 0);
+    return ftpd_session_send(sess, buf, len);
 }
 
 /* --------------------------------------------------------------------
@@ -403,16 +453,21 @@ ftpd_session_run(void *udata, CTHDWORK *work)
         ftpd_log(LOG_INFO, "%s: session started, socket %d", __func__,
                  sess->ctrl_sock);
 
-        /* Send 220 greeting */
-        ftpd_session_reply(sess, FTP_220, "%s", server->config.banner);
-        sess->state = SESS_AUTH_USER;
+        /* Send 220 greeting.  Only advance the state if it went out --
+        ** otherwise the assignment would overwrite the SESS_CLOSING that
+        ** the failed write just set. */
+        if (ftpd_session_reply(sess, FTP_220, "%s",
+                               server->config.banner) == 0)
+            sess->state = SESS_AUTH_USER;
 
         /* Consecutive per-command ABEND recoveries; reset on any clean
         ** command so the guard only trips on a wedged session. */
         recover_count = 0;
 
-        /* Command loop */
-        while (sess->state != SESS_CLOSING) {
+        /* Command loop.  ctrl_dead is tested separately from the state:
+        ** a handler that sets its own state after a failed reply would
+        ** otherwise clear SESS_CLOSING again. */
+        while (sess->state != SESS_CLOSING && !sess->ctrl_dead) {
             if (work->state == CTHDWORK_STATE_SHUTDOWN)
                 break;
 


### PR DESCRIPTION
Fixes #104

## Approach: one sink, not 200 call sites

`ftpd_session_reply()` alone has ~197 callers across eight files. Rewriting them would be a large diff with real regression risk and no structural guarantee — the next unchecked call reintroduces the problem. Instead, the four places that actually write to the control socket (`ftpd_session_reply()`, both writes in `ftpd_session_reply_multi()`, and `cmd_feat()`) now funnel through a new `ftpd_session_send()`, which:

- completes short writes,
- logs a failure **once per session** (a dead control connection otherwise produces one message per queued reply),
- sets `ctrl_dead` and moves the session to `SESS_CLOSING`.

Callers may keep ignoring the return value and still terminate correctly — the command loop ends on its next iteration. `ftpd_session_reply()` and `ftpd_session_reply_multi()` now return `int`; that is source-compatible, since C permits discarding a return value, and the build confirms no call site needed touching.

The trace line moved behind the success check: a reply that never reached the client no longer appears in the trace as if it had.

## Why `ctrl_dead` is separate from the session state

A handler that assigns its own state after a failed reply would clear `SESS_CLOSING` again. That is not hypothetical — the 220 greeting did exactly that (`ftpd_session_reply(...)` followed unconditionally by `sess->state = SESS_AUTH_USER;`). The greeting now only advances the state when the write succeeded, and the command loop tests the flag as well, so the guarantee does not depend on all ~200 handlers behaving.

## Deliberately not done here

No retry, and no interpretation of transport-level return codes. The control connection is a **blocking** socket — `FIONBIO` is set only on the listening socket, for the accept poll (`src/ftpd.c:418`) — so waiting out a temporarily full send buffer belongs in the C library, not here. Anything negative that reaches FTPD means the peer is gone.

That split is the coordination agreed in mvslovers/libc370#120: per socket type, exactly one layer waits. **libc370#120 should land before this is deployed.** Until it does, a patched Hercules can return a "would block" code straight through to FTPD, and this change would then close a session on a transiently full buffer. The window is small (control replies are under 512 bytes) and only exists on a system with a patched emulator and an unpatched libc370.

## Also fixed

`ftpd_data_send()` (`src/ftpd#dat.c`) logged `errno` for every non-positive return, though `errno` only carries a diagnosis when `send()` itself failed. For any other value it printed a leftover from an earlier call that reads like a real cause. It now logs the actual return code and the byte counts, and only reports `errno` when it means something.

## Verification

- `make` clean (cc370, `-Wall -Werror`), `make test-host` 72 assertions pass (TSTADR 29, TSTDSN 43).
- Not yet exercised against a live client. The observable behaviour to check on MVS: kill an FTP client mid-session (so the control connection is gone but the server still has replies to write) and confirm a single `control write failed ... closing session` in the log, the session ending promptly, and the worker returning to the pool.