### PR TITLE
Stop reading a dataset once the client is gone

### DIFF
--- a/src/ftpd#mvs.c
+++ b/src/ftpd#mvs.c
@@ -1237,6 +1237,7 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
     long total;
     int lrecl;
     int is_fixed;
+    int aborted = 0;            /* data connection died mid-transfer */
 
     if (!arg || !arg[0]) {
         ftpd_session_reply(sess, FTP_501, "Missing dataset name");
@@ -1336,15 +1337,18 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
 
         if (lrecl > 0) {
             while ((n = fread(buf, 1, lrecl, fp)) > 0) {
-                ftpd_data_send(sess, buf, (int)n);
+                if (ftpd_data_send(sess, buf, (int)n) < 0) {
+                    aborted = 1;
+                    break;
+                }
                 total += n;
                 recnum++;
             }
         }
 
         ftpd_log(LOG_INFO,
-                 "RETR BIN: done sent=%ld records=%d lrecl=%d",
-                 total, recnum, lrecl);
+                 "RETR BIN: %s sent=%ld records=%d lrecl=%d",
+                 aborted ? "ABORTED" : "done", total, recnum, lrecl);
     }
     else if (sess->type == XFER_TYPE_A) {
         /* ---------------------------------------------------------------
@@ -1366,7 +1370,10 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
 
                 buf[end]     = ASCII_CR;
                 buf[end + 1] = ASCII_LF;
-                ftpd_data_send(sess, buf, end + 2);
+                if (ftpd_data_send(sess, buf, end + 2) < 0) {
+                    aborted = 1;
+                    break;
+                }
                 total += end + 2;
             }
         }
@@ -1375,13 +1382,17 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
         /* TYPE E: send EBCDIC as-is, fread lrecl bytes per record */
         if (lrecl > 0) {
             while ((n = fread(buf, 1, lrecl, fp)) > 0) {
-                ftpd_data_send(sess, buf, (int)n);
+                if (ftpd_data_send(sess, buf, (int)n) < 0) {
+                    aborted = 1;
+                    break;
+                }
                 total += n;
             }
         }
     }
 
-    ftpd_log(LOG_INFO, "RETR: closing %s", fname);
+    ftpd_log(LOG_INFO, "RETR: %s %s after %ld bytes",
+             aborted ? "aborting" : "closing", fname, total);
     sess->cur_file = NULL;
     fclose(fp);
     ftpd_data_close(sess);
@@ -1390,6 +1401,17 @@ ftpd_mvs_retr(ftpd_session_t *sess, const char *arg)
     sess->xfer_count++;
     if (sess->server) {
         sess->server->total_bytes_out += total;
+    }
+
+    /* An aborted transfer must not be reported as a completed one -- the
+    ** client is left with an incomplete data set and has to know.  total
+    ** counts only what actually left the machine, so it is the honest
+    ** number to report. */
+    if (aborted) {
+        ftpd_session_reply(sess, FTP_426,
+                           "Transfer aborted: data connection lost "
+                           "after %ld bytes.", total);
+        return 0;
     }
 
     ftpd_session_reply(sess, FTP_250,


### PR DESCRIPTION
Fixes #106

## The change

The three MVS send loops in `ftpd_mvs_retr()` (TYPE I, A and E) now break when `ftpd_data_send()` returns negative, so a transfer stops where the connection did instead of reading the data set to EOF for a client that is no longer there. The JES and UFS paths have always done this; MVS datasets were the outlier.

The completion path told the same untruth and is fixed with it: it replied `250 Transfer completed successfully` unconditionally, so an aborted transfer looked like a good one both to the client and in the log, and the byte counters included records that never left the machine. An aborted transfer now answers **`426`** with the number of bytes that actually went out, and the log line says `aborting`/`ABORTED` rather than `done`. Because the loops break, `total` is once again the honest count feeding `sess->bytes_sent` and `total_bytes_out`.

## Verified live on MVS

Build `50F1D64` (this branch), activated into `FTPD.V1R0M0.LINKLIB`, STC restarted — the startup line confirms the running module: `FTPD000I FTPD 1.0.1-DEV (50F1D64)`.

**The case from #106** — `RETR SMPBKUP.SMPPTS` (2693 tracks, ~51 MB), client stops reading and then drops the data connection:

| | before | after |
|---|---|---|
| session active after client vanished | ~90 s | **0.7 s** |
| control reply | `250 Transfer completed successfully.` | `426 Transfer aborted: data connection lost after 228672 bytes.` |
| remaining data set | read to EOF from DASD | not read |

`F FTPD,SESSIONS` right afterwards: `0 / 10`. The control connection survives the aborted transfer — `QUIT` still answered `221` — which is correct: a dead data connection is not a dead session.

**Regression, normal transfers still report 250:**

* TYPE I, `FTPD.SAMP.XMIT` read to completion → `250`, 10000 bytes.
* TYPE A, same data set → `250`, 7972 bytes (shorter than binary because ASCII mode trims trailing blanks and adds CRLF — expected).
* TYPE A on an empty data set → `250`, 0 bytes. Checked that this is genuinely an empty data set (`GET /zosmf/restfiles/ds/IBMUSER.CURL.MALF` returns 0 bytes) and not the new break firing early.

## Scope note

`ftpd_ufs_retr()` (`src/ftpd#ufs.c:465`) breaks correctly on a send error but then still replies `226 Transfer complete` — the same "aborted transfer reported as successful" flaw this PR fixes for MVS datasets. Left alone deliberately to keep this change to one file and one path; happy to follow up if wanted.