### PR TITLE
Keep FTPD out of its own module storage (#101)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,3 +8,21 @@ on:
 jobs:
   build:
     uses: mvslovers/mbt/.github/workflows/build.yml@main
+
+  # FTPD is AC(1).  Fetched from an APF-authorized library it is loaded into
+  # key-0 storage, so a key-8 store into its own statics abends S0C4 before
+  # the first WTO (#101).  The build cannot see that -- this can.
+  module-data:
+    name: No writable data in AC(1) modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Check module data
+        run: python3 tools/check-module-data.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,26 @@ Standalone FTP daemon for MVS 3.8j. Not tied to HTTPD.
 Supports native MVS datasets, UFS (via UFSD), and JES (job submit/spool).
 z/OS-compatible SITE commands and dataset name handling.
 
+### No writable module data — FTPD is AC(1)
+
+**Never add a mutable file-scope variable or a function-local `static` to a
+`[[module]]` source.** FTPD is link-edited `AC(1)`. Fetched from an
+APF-authorized library, the job step is authorized before program fetch, so
+MVS loads the module into subpool 252 **key 0**; the STC runs problem state
+key 8, and any store into module storage abends S0C4 (#101). It also breaks
+the RENT/REUS attributes ld370 puts on the module by default.
+
+Where state goes instead: into `struct ftpd_server` (a `main()` local, key 8)
+and published process-wide through the GRT — `grtapp1` anchors the server for
+dump reading, `grtapp2` the log/trace block that `ftpd#log.c` reads on every
+call. `ftpd_log_anchor()` is the pattern to copy. A subtask inherits the GRT
+from its mother task (`@@CRTSET`), so worker threads see it. Tables that are
+only ever read are `const` instead.
+
+`tools/check-module-data.py` enforces it and runs as its own CI job. It is a
+text proxy — the real check is `cc370 -S` plus a look for a store through a
+register loaded from `=A(@Vn)` or into an X-var.
+
 ### Dependencies
 
 - **crent370** (required): C runtime — sockets, thdmgr (threads), jes, racf, os, emfile, ipc

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -117,6 +117,17 @@ clean alternative is to add `FTPD.<vrm>.LINKLIB` to the APF list in
 library name carries the version — so this is one IPL per release, not one IPL
 ever.
 
+The two routes are not equivalent in one respect that matters if you ever have
+to debug FTPD. An **APF entry** authorises the job step *before* program fetch,
+so MVS loads FTPD into subpool 252 **key 0** — authorised code must not be
+patchable by problem-key code. **SVC 244** sets `JSCBAUTH` *after* the fetch and
+cannot relabel storage that is already allocated, so the module stays key 8.
+FTPD runs problem state key 8 either way, which means that under an APF entry it
+must never store into its own module storage. It does not, as of 1.0.1: the
+server block, the log level and the trace ring all live in `main()`'s storage
+and are reached through the C runtime's process anchor. **On 1.0.0 an APF entry
+kills FTPD outright** — see the `S0C4` row under Troubleshooting.
+
 Unlike UFSD, FTPD **warns and keeps running** when authorisation fails:
 
 ```
@@ -490,6 +501,7 @@ in step 7, and your RAKF definitions. Those are yours to delete.
 | `550 UFS service not available` | The UFSD started task is not running (installed is not enough) |
 | Passive transfer stalls after `227` | `PASVPORTS` not reachable, or `PASVADR` wrong behind NAT — step 7 |
 | `S106` at start on a freshly installed library | The XMIT was uploaded in text mode. Re-upload in **binary** and re-run the install job |
+| `S0C4` at start, JESMSGLG holds only the `IEF450I` — no `FTPD000I`, no banner | FTPD 1.0.0 started from an **APF-authorised** LINKLIB. The module is then key 0 and the first store into its own storage abends before the first WTO. Upgrade to 1.0.1, or take the APF entry back out and let SVC 244 authorise instead — step 2 |
 
 For the RAKF message reference, see
 [FTPD_RAKF_SETUP.md](https://github.com/mvslovers/ftpd/blob/main/doc/FTPD_RAKF_SETUP.md).

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -128,6 +128,19 @@ server block, the log level and the trace ring all live in `main()`'s storage
 and are reached through the C runtime's process anchor. **On 1.0.0 an APF entry
 kills FTPD outright** — see the `S0C4` row under Troubleshooting.
 
+You do not have to work out which route you got: FTPD says so at startup, on
+the line after the version banner.
+
+```
+FTPD008I AUTHORIZED BY LIBRARY (MODULE KEY 0)     APF list entry
+FTPD008I AUTHORIZED BY SVC (MODULE KEY 8)         SVC 244, from RAKF
+```
+
+The key is inferred from the route rather than measured — an authorised job
+step has its module fetched key 0, an unauthorised one key 8, and SVC 244
+arrives too late to change either. Neither line is a warning: both routes end
+in an authorised started task, and which one you want is a site decision.
+
 Unlike UFSD, FTPD **warns and keeps running** when authorisation fails:
 
 ```
@@ -411,6 +424,7 @@ A healthy start ends in `FTPD001I … READY`:
 ```
 FTPD000I FTPD <version> (A3F2C91) STARTING
 FTPD005I LIBC370 V1.0.2 (22B4870)
+FTPD008I AUTHORIZED BY SVC (MODULE KEY 8)
 FTPD004I STC IDENTITY SET TO FTPD/USER VIA RACINIT
 FTPD054I LISTENING ON 0.0.0.0 PORT 2121
 FTPD001I FTPD <version> READY
@@ -420,6 +434,11 @@ The two build stamps identify exactly what is running: `FTPD000I` gives the
 version and the commit it was built from, `FTPD005I` the libc370 it was linked
 against — quote both in a bug report. A build made from a modified working tree
 marks its hash `-DIRTY` and adds `FTPD006W`; a released build never does.
+
+`FTPD008I` says which of the two authorisation routes the start took, and
+reads `AUTHORIZED BY LIBRARY (MODULE KEY 0)` on a system with the LINKLIB in
+the APF list — see step 2. Quote it in a bug report too: it decides the storage
+key FTPD's own module runs in.
 
 Then log in from a client:
 

--- a/include/ftpd#log.h
+++ b/include/ftpd#log.h
@@ -15,6 +15,42 @@
 #define LOG_DEBUG           3
 
 /*
+** Log and trace state.
+**
+** Not file-scope data in ftpd#log.c, where it used to live: FTPD is
+** link-edited AC(1), and fetched from an APF-authorized library the job
+** step is authorized before program fetch runs, so MVS obtains the job
+** pack area in subpool 252 key 0 -- authorized code must not be patchable
+** by problem-key code.  The STC runs problem state key 8, so every store
+** into the module's own storage is a protection exception (#101).
+**
+** It lives in ftpd_server (a main() local, hence key 8) and is published
+** for the whole process by ftpd_log_anchor().  The struct is here rather
+** than in ftpd.h so ftpd#log.c can stay off ftpd.h and out of sockets,
+** RACF and the thread manager.
+*/
+typedef struct ftpd_logst {
+    int             level;          /* current log level             */
+    char            *trace_buf;     /* trace ring storage            */
+    int             trace_size;     /* number of entries             */
+    int             trace_head;     /* next write position           */
+    int             trace_count;    /* total entries written         */
+    int             trace_on;       /* tracing enabled flag          */
+} ftpd_logst_t;
+
+/*
+** Publish the log/trace state for the process.  Call once from main(),
+** before the first ftpd_log() or ftpd_trace() -- and set `level` first,
+** because a memset server leaves it at LOG_ERROR.
+**
+** Until this is called (and if it ever fails) ftpd_log() falls back to
+** LOG_INFO and tracing stays off; ftpd_log_wto() keeps no state and works
+** either way.  Worker threads see the same state: a subtask inherits the
+** GRT from its mother task (@@CRTSET), so it is process-level.
+*/
+void ftpd_log_anchor(ftpd_logst_t *st)                      asm("FTPLOGAN");
+
+/*
 ** Write a message to the operator console (WTO).
 ** Use for important events only: startup, shutdown, errors, console responses.
 ** Format: FTPDnnnX message

--- a/include/ftpd#xlt.h
+++ b/include/ftpd#xlt.h
@@ -16,9 +16,13 @@
 #define ASCII_LF   0x0A
 #define ASCII_CRLF "\x0D\x0A"
 
-/* Active translation table pointers — always IBM-1047 */
-extern unsigned char *asc2ebc;
-extern unsigned char *ebc2asc;
+/* Active translation table pointers — always IBM-1047.
+**
+** const both ways on purpose: an AC(1) module fetched from an APF-
+** authorized library is key-0 storage, so reassigning either pointer
+** from the key-8 STC is an S0C4 (#101), not a codepage switch. */
+extern const unsigned char * const asc2ebc;
+extern const unsigned char * const ebc2asc;
 
 /* In-place buffer translation (active tables = IBM-1047) */
 void ftpd_xlat_a2e(unsigned char *buf, int len)                 asm("FTPXLA2E");

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -155,6 +155,11 @@ struct ftpd_server {
 #define FTPD_QUIESCE        0x02    /* shutdown in progress          */
 
     ftpd_config_t   config;         /* server configuration          */
+    ftpd_logst_t    log;            /* log level + trace ring state;
+                                    ** here rather than file scope in
+                                    ** ftpd#log.c because module storage
+                                    ** is key 0 under APF (#101).  Read
+                                    ** through grtapp2, not this field  */
     char            enq_rname[16];  /* "FTPD.PORT.nnnnn": the single
                                     ** instance ENQ, held by main's TCB
                                     ** for the life of the server      */
@@ -178,8 +183,6 @@ struct ftpd_server {
                                     ** (STC-lifetime; observability for
                                     ** documented residual leaks)      */
 };
-
-extern ftpd_server_t *ftpd_server;
 
 /*
 ** Process a Console Information Block (operator command).

--- a/src/ftpd#log.c
+++ b/src/ftpd#log.c
@@ -12,23 +12,46 @@
 #include <stdarg.h>
 #include <ctype.h>
 
+#include "clibgrt.h"
 #include "clibwto.h"
 #include "ftpd#log.h"
 
 /* --- Log level names --- */
 static const char *level_names[] = { "ERROR", "WARN ", "INFO ", "DEBUG" };
 
-/* --- Current log level (default INFO) --- */
-static int log_level = LOG_INFO;
-
 /* --- Trace ring buffer --- */
 #define TRACE_ENTRY_LEN     120     /* max length of one trace entry  */
 
-static char     *trace_buf = NULL;  /* ring buffer storage            */
-static int      trace_size = 0;     /* number of entries              */
-static int      trace_head = 0;     /* next write position            */
-static int      trace_count = 0;    /* total entries written          */
-static int      trace_on = 0;       /* tracing enabled flag           */
+/* ====================================================================
+** Log/trace state
+**
+** All of it used to be file-scope variables here.  In an AC(1) module
+** fetched from an APF-authorized library that storage is key 0 and a
+** store from the key-8 STC abends S0C4 (#101), so the state now lives in
+** ftpd_server -- a main() local -- and is reached through grtapp2.
+**
+** The GRT is per process and inherited by every subtask (@@CRTSET copies
+** crtgrt from the mother task's CLIBCRT), so a session worker resolves
+** the same block main published.  A NULL slot means main has not got
+** there yet: the callers below fall back to LOG_INFO and no tracing
+** rather than to a wild store.
+** ================================================================= */
+static ftpd_logst_t *
+logst(void)
+{
+    CLIBGRT *grt = __grtget();
+
+    return grt ? (ftpd_logst_t *)grt->grtapp2 : NULL;
+}
+
+void
+ftpd_log_anchor(ftpd_logst_t *st)
+{
+    CLIBGRT *grt = __grtget();
+
+    if (grt)
+        grt->grtapp2 = st;
+}
 
 /* ====================================================================
 ** WTO logging
@@ -77,8 +100,9 @@ ftpd_log(int level, const char *fmt, ...)
     char buf[256];
     va_list ap;
     const char *lvl;
+    ftpd_logst_t *st = logst();
 
-    if (level > log_level)
+    if (level > (st ? st->level : LOG_INFO))
         return;
 
     lvl = (level >= 0 && level <= LOG_DEBUG) ? level_names[level] : "?????";
@@ -93,14 +117,18 @@ ftpd_log(int level, const char *fmt, ...)
 void
 ftpd_log_set_level(int level)
 {
-    if (level >= LOG_ERROR && level <= LOG_DEBUG)
-        log_level = level;
+    ftpd_logst_t *st = logst();
+
+    if (st && level >= LOG_ERROR && level <= LOG_DEBUG)
+        st->level = level;
 }
 
 int
 ftpd_log_get_level(void)
 {
-    return log_level;
+    ftpd_logst_t *st = logst();
+
+    return st ? st->level : LOG_INFO;
 }
 
 /* ====================================================================
@@ -109,17 +137,22 @@ ftpd_log_get_level(void)
 int
 ftpd_trace_init(int size)
 {
+    ftpd_logst_t *st = logst();
+
+    if (!st)
+        return -1;
+
     if (size < 1)
         size = 256;
 
-    trace_buf = calloc(size, TRACE_ENTRY_LEN);
-    if (!trace_buf)
+    st->trace_buf = calloc(size, TRACE_ENTRY_LEN);
+    if (!st->trace_buf)
         return -1;
 
-    trace_size = size;
-    trace_head = 0;
-    trace_count = 0;
-    trace_on = 0;
+    st->trace_size = size;
+    st->trace_head = 0;
+    st->trace_count = 0;
+    st->trace_on = 0;
 
     return 0;
 }
@@ -127,14 +160,19 @@ ftpd_trace_init(int size)
 void
 ftpd_trace_free(void)
 {
-    if (trace_buf) {
-        free(trace_buf);
-        trace_buf = NULL;
+    ftpd_logst_t *st = logst();
+
+    if (!st)
+        return;
+
+    if (st->trace_buf) {
+        free(st->trace_buf);
+        st->trace_buf = NULL;
     }
-    trace_size = 0;
-    trace_head = 0;
-    trace_count = 0;
-    trace_on = 0;
+    st->trace_size = 0;
+    st->trace_head = 0;
+    st->trace_count = 0;
+    st->trace_on = 0;
 }
 
 void
@@ -142,61 +180,73 @@ ftpd_trace(const char *fmt, ...)
 {
     char *entry;
     va_list ap;
+    ftpd_logst_t *st = logst();
 
-    if (!trace_on || !trace_buf)
+    if (!st || !st->trace_on || !st->trace_buf)
         return;
 
-    entry = trace_buf + (trace_head * TRACE_ENTRY_LEN);
+    entry = st->trace_buf + (st->trace_head * TRACE_ENTRY_LEN);
 
     va_start(ap, fmt);
     vsnprintf(entry, TRACE_ENTRY_LEN, fmt, ap);
     va_end(ap);
 
-    trace_head = (trace_head + 1) % trace_size;
-    trace_count++;
+    st->trace_head = (st->trace_head + 1) % st->trace_size;
+    st->trace_count++;
 }
 
 void
 ftpd_trace_enable(int on)
 {
-    trace_on = on;
-    if (on && !trace_buf) {
+    ftpd_logst_t *st = logst();
+
+    if (!st)
+        return;
+
+    /* Allocate first, enable second.  ftpd_trace_init() resets trace_on,
+    ** so the old order left TRACE ON reporting FTPD080I with tracing
+    ** still off -- unreachable today because initialize() allocates the
+    ** ring at startup, but wrong the moment that stops being true. */
+    if (on && !st->trace_buf)
         ftpd_trace_init(256);
-    }
+
+    st->trace_on = on;
 }
 
 int
 ftpd_trace_dump(void)
 {
     int i, idx, count;
+    ftpd_logst_t *st = logst();
 
-    if (!trace_buf) {
+    if (!st || !st->trace_buf) {
         printf("Trace buffer not initialized\n");
         return 0;
     }
 
-    count = (trace_count < trace_size) ? trace_count : trace_size;
+    count = (st->trace_count < st->trace_size) ? st->trace_count
+                                               : st->trace_size;
     if (count == 0) {
         printf("Trace buffer empty\n");
         return 0;
     }
 
     /* Start from oldest entry */
-    if (trace_count >= trace_size) {
-        idx = trace_head;  /* oldest is at head (about to be overwritten) */
+    if (st->trace_count >= st->trace_size) {
+        idx = st->trace_head;  /* oldest is at head (next overwritten) */
     } else {
-        idx = 0;           /* buffer not yet wrapped */
+        idx = 0;               /* buffer not yet wrapped */
     }
 
     printf("--- Trace dump: %d entries (%d total written) ---\n",
-           count, trace_count);
+           count, st->trace_count);
 
     for (i = 0; i < count; i++) {
-        char *entry = trace_buf + (idx * TRACE_ENTRY_LEN);
+        char *entry = st->trace_buf + (idx * TRACE_ENTRY_LEN);
         if (entry[0] != '\0') {
             printf("[%04d] %s\n", i, entry);
         }
-        idx = (idx + 1) % trace_size;
+        idx = (idx + 1) % st->trace_size;
     }
 
     printf("--- End of trace dump ---\n");
@@ -207,5 +257,7 @@ ftpd_trace_dump(void)
 int
 ftpd_trace_enabled(void)
 {
-    return trace_on;
+    ftpd_logst_t *st = logst();
+
+    return st ? st->trace_on : 0;
 }

--- a/src/ftpd#xlt.c
+++ b/src/ftpd#xlt.c
@@ -22,7 +22,7 @@
 /* Active default — FTP protocol I/O + UFS file content               */
 /* ================================================================== */
 
-static unsigned char ibm1047_atoe[256] = {
+static const unsigned char ibm1047_atoe[256] = {
     /* 0x00-0x07 */ 0x00, 0x01, 0x02, 0x03, 0x37, 0x2D, 0x2E, 0x2F,
     /* 0x08-0x0F */ 0x16, 0x05, 0x15, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     /* 0x10-0x17 */ 0x10, 0x11, 0x12, 0x13, 0x3C, 0x3D, 0x32, 0x26,
@@ -57,7 +57,7 @@ static unsigned char ibm1047_atoe[256] = {
     /* 0xF8-0xFF */ 0x70, 0xDD, 0xDE, 0xDB, 0xDC, 0x8D, 0x8E, 0xDF
 };
 
-static unsigned char ibm1047_etoa[256] = {
+static const unsigned char ibm1047_etoa[256] = {
     /* 0x00-0x07 */ 0x00, 0x01, 0x02, 0x03, 0x9C, 0x09, 0x86, 0x7F,
     /* 0x08-0x0F */ 0x97, 0x8D, 0x8E, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     /* 0x10-0x17 */ 0x10, 0x11, 0x12, 0x13, 0x9D, 0x0A, 0x08, 0x87,
@@ -96,7 +96,7 @@ static unsigned char ibm1047_etoa[256] = {
 /* IBM Code Page 037 (CECP US/Canada) — for MVS dataset content       */
 /* ================================================================== */
 
-static unsigned char cp037_atoe[256] = {
+static const unsigned char cp037_atoe[256] = {
     /* 0x00-0x07 */ 0x00, 0x01, 0x02, 0x03, 0x37, 0x2D, 0x2E, 0x2F,
     /* 0x08-0x0F */ 0x16, 0x05, 0x15, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     /* 0x10-0x17 */ 0x10, 0x11, 0x12, 0x13, 0x3C, 0x3D, 0x32, 0x26,
@@ -131,7 +131,7 @@ static unsigned char cp037_atoe[256] = {
     /* 0xF8-0xFF */ 0x70, 0xDD, 0xDE, 0xDB, 0xDC, 0x8D, 0x8E, 0xDF
 };
 
-static unsigned char cp037_etoa[256] = {
+static const unsigned char cp037_etoa[256] = {
     /* 0x00-0x07 */ 0x00, 0x01, 0x02, 0x03, 0x9C, 0x09, 0x86, 0x7F,
     /* 0x08-0x0F */ 0x97, 0x8D, 0x8E, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     /* 0x10-0x17 */ 0x10, 0x11, 0x12, 0x13, 0x9D, 0x0A, 0x08, 0x87,
@@ -168,10 +168,24 @@ static unsigned char cp037_etoa[256] = {
 
 /* ================================================================== */
 /* Active pointers — always IBM-1047                                  */
+/*                                                                    */
+/* Both the tables and the pointers to them are const, and that is    */
+/* not decoration.  FTPD is link-edited AC(1): fetched from an APF-   */
+/* authorized library its module storage is key 0 while the STC runs  */
+/* key 8, so anything written here abends S0C4 (#101).  A codepage    */
+/* switch that reassigned one of these pointers would be exactly that */
+/* bug -- it is what killed HTTPD in http_xlate_init (httpd#197).     */
+/* Read-only, they are never written after program fetch and cost     */
+/* nothing.  A per-session codepage belongs in ftpd_session, not here.*/
+/*                                                                    */
+/* The names are shared with libc370 (src/dyn75/asc2ebc.c) and httpd, */
+/* where they are plain `unsigned char *`.  Keeping the pointer shape */
+/* keeps that ABI: nothing in libc370 references them today, but an   */
+/* array here would silently become garbage to anything that did.     */
 /* ================================================================== */
 
-unsigned char *asc2ebc = ibm1047_atoe;
-unsigned char *ebc2asc = ibm1047_etoa;
+const unsigned char * const asc2ebc = ibm1047_atoe;
+const unsigned char * const ebc2asc = ibm1047_etoa;
 
 /* ================================================================== */
 /* Translation functions                                              */

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -19,13 +19,11 @@
 
 #include "ftpd.h"
 #include "ftpd#ses.h"
+#include "clibgrt.h"
 #include "clibppa.h"
 #include "clibos.h"
 #include "clibenq.h"
 #include "clibver.h"
-
-/* Global server state */
-ftpd_server_t *ftpd_server = NULL;
 
 /* Forward declarations */
 static int  socket_thread(void *arg1, void *arg2);
@@ -39,6 +37,7 @@ int
 main(int argc, char **argv)
 {
     ftpd_server_t server;
+    CLIBGRT *grt;
     COM *com;
     CIB *cib;
     int rc;
@@ -50,7 +49,31 @@ main(int argc, char **argv)
     memset(&server, 0, sizeof(server));
     strcpy(server.eye, FTPD_EYE);
     server.flags |= FTPD_ACTIVE;
-    ftpd_server = &server;
+
+    /* --- Publish the server, before anything can want it ------------
+    ** The server block is a main() local on purpose.  It used to be
+    ** anchored in a module-scope `ftpd_server` pointer, and that single
+    ** store was enough to kill FTPD outright the moment FTPD.LINKLIB got
+    ** an APF entry: an AC(1) module fetched from an authorized library
+    ** lands in subpool 252 key 0, the STC runs problem state key 8, and
+    ** the store abends S0C4 here -- ahead of the first WTO, so the whole
+    ** JESMSGLG was one IEF450I and nothing else (#101).
+    **
+    ** The GRT is the process-level home for exactly this: heap, key 8,
+    ** and inherited by every subtask, so a session worker sees what main
+    ** put there.  grtapp1 is the anchor a dump reader follows to the
+    ** server (no code reads it); grtapp2 carries the log/trace state,
+    ** which ftpd#log.c does read, on every ftpd_log() and ftpd_trace().
+    **
+    ** level first, anchor second: the memset above leaves it at
+    ** LOG_ERROR, and everything from here on logs.
+    */
+    server.log.level = LOG_INFO;
+    ftpd_log_anchor(&server.log);
+
+    grt = __grtget();
+    if (grt)
+        grt->grtapp1 = &server;
 
     /* Get COM area and set CIB limit BEFORE creating any threads.
     **

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -42,6 +42,7 @@ main(int argc, char **argv)
     CIB *cib;
     int rc;
     int apf_rc;
+    int apf_at_entry;           /* authorized before clib_apf_setup()?   */
     char vers[24];              /* MBT_VERSION, upper case: FTPD000I+001I */
 
     (void)argc;
@@ -106,7 +107,15 @@ main(int argc, char **argv)
     ** message saying which server is starting.  FTPD warns and continues
     ** where UFSD gives up -- the commands that need authorization fail
     ** individually and say so.
+    **
+    ** Ask __isauth() first.  Which route authorizes the STC decides
+    ** whether its own module storage is writable -- authorized at entry
+    ** means the job step was already authorized when program fetch ran,
+    ** so MVS took the job pack area in subpool 252 key 0 (#101) -- and
+    ** clib_apf_setup() destroys the distinction by returning 0 either
+    ** way.  One TESTAUTH, no supervisor state.
     */
+    apf_at_entry = __isauth();
     apf_rc = clib_apf_setup(argv[0]);
 
     /* --- Startup banner ------------------------------------------
@@ -130,8 +139,23 @@ main(int argc, char **argv)
 #endif
     }
 
+    /* Which route got us here, and what it costs.  Both routes end in an
+    ** authorized task and neither says a word on its own: clib_apf_setup()
+    ** returns 0 either way and libc370's diagnostics on that path are
+    ** commented out.  That silence is what made #101 hard to place -- the
+    ** route is what decides whether FTPD's own module storage is writable,
+    ** so it belongs next to the version banner.
+    **
+    ** The key is inferred from the route, not measured: an authorized job
+    ** step has its module fetched key 0, an unauthorized one key 8, and
+    ** SVC 244 arrives too late to change either.
+    */
     if (apf_rc)
         ftpd_log_wto("FTPD003W APF SETUP FAILED RC=%d", apf_rc);
+    else if (apf_at_entry)
+        ftpd_log_wto("FTPD008I AUTHORIZED BY LIBRARY (MODULE KEY 0)");
+    else
+        ftpd_log_wto("FTPD008I AUTHORIZED BY SVC (MODULE KEY 8)");
 
     /* Initialize server (config, trace, socket thread, worker pool) */
     rc = initialize(&server);

--- a/tools/check-module-data.py
+++ b/tools/check-module-data.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Reject writable file-scope data in the AC(1) load modules.
+
+Why this exists (issue #101)
+----------------------------
+FTPD is link-edited AC(1).  Fetched from an APF-authorized library, the job
+step is authorized before program fetch runs, and MVS then obtains the job
+pack area in subpool 252 with **storage key 0** so that problem-key code
+cannot patch authorized code.  The STC itself runs problem state key 8.
+Every store into the module's own storage -- i.e. every write to a C static
+or a non-const global -- therefore takes a protection exception.
+
+FTPD's own was the first line of main(), `ftpd_server = &server`, ahead of
+the first WTO.  The entire JESMSGLG of a start on an APF-authorized
+FTPD.LINKLIB was one line:
+
+    12.34.30 STC 1124  IEF450I FTPD FTPD - ABEND S0C4 U0000 - TIME=12.34.30
+
+Without APF the same module is fetched key 8 and the store goes through
+unnoticed, which is why this only shows up on hardened systems.  Authorizing
+ourselves later via SVC 244 (clib_apf_setup) does not change it either way:
+that sets JSCBAUTH, it cannot relabel storage program fetch already
+allocated.
+
+There is a second reason, independent of authorization: ld370 marks a load
+module RENT and REUS unless the module opts out with `norent` / `noreus`, and
+FTPD does not.  Writable module data breaks that promise outright, and would
+fail the same way in the (key 0, page-protected) LPA.
+
+So: no mutable file-scope data in an AC(1) module.  Put the value in
+ftpd_server (a main() local, key 8, published process-wide through the GRT --
+see ftpd_log_anchor() for the pattern), on the heap, or in CSA behind the
+usual key-0 window.  Making it `const` is the other answer, and the right one
+for tables that are only ever read.
+
+An absent `ac` counts as 0, matching mbt -- see mbtconfig.py,
+`mod.get("ac", 0)` -- so an AC(0) module is not checked: the job step is
+never authorized, and MVS fetches it key 8.
+
+Scope and limits
+----------------
+Only `[[module]]` sources are checked.  ufsd's `client/libufs.c` is linked
+into FTPD and is not covered here (different repo); scanned with this same
+detector for #101, it has no module-resident data at all.
+
+libc370 is out of reach too.  Its module-resident statics are real, but the
+ones on FTPD's paths are no-CRT fallbacks -- `errno` resolves through
+`crt->crterrno` whenever a CLIBCRT exists, which under the STC it always
+does.
+
+This is a text proxy, not the check.  It cannot tell a `const` pointer from a
+pointer to const, and it does not see assembler.  The precise cross-check is
+to compile with `cc370 -S` and look for a store through a register loaded
+from `=A(@Vn)` or an X-var -- that is what found the offenders in the first
+place, and what confirmed the fix.
+
+Ecosystem note: this file is a copy of ufsd's (mvslovers/ufsd#66), which found
+FTPD's bug.  Keep them in step until mbt grows a shared home for it.
+
+Usage: tools/check-module-data.py [project.toml]
+"""
+
+import glob
+import os
+import re
+import sys
+
+try:
+    import tomllib
+except ImportError:                                     # Python < 3.11
+    sys.exit("check-module-data: needs Python 3.11+ (tomllib)")
+
+
+def strip_noise(src):
+    """Blank out comments, string/char literals and preprocessor lines.
+
+    Newlines are preserved so reported line numbers stay usable.
+    """
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == '/' and src[i:i + 2] == '/*':
+            j = src.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(ch if ch == '\n' else ' ' for ch in src[i:j]))
+            i = j
+            continue
+        if c == '/' and src[i:i + 2] == '//':
+            j = src.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+            continue
+        if c in '"\'':
+            quote, j = c, i + 1
+            while j < n and src[j] != quote:
+                j += 2 if src[j] == '\\' else 1
+            out.append('""' + ' ' * max(0, j - i - 1))
+            i = j + 1
+            continue
+        out.append(c)
+        i += 1
+    text = ''.join(out)
+    return '\n'.join('' if l.lstrip().startswith('#') else l
+                     for l in text.split('\n'))
+
+
+def declarations(src):
+    """Yield (line, text, depth) for every statement, file scope and inside
+    function bodies alike -- a function-local `static` is module storage too.
+
+    A '{' right after '=' or ',' opens an initializer, not a block.  The
+    declarator that closes a `typedef struct { ... } NAME;` is a type name, not
+    data -- but `struct tag { ... } instance;` is data, so only typedef tails
+    are dropped.
+    """
+    depth, init, buf, line, start = 0, 0, '', 1, 1
+    heads, typetail = [], False
+    for ch in src:
+        if ch == '\n':
+            line += 1
+        if ch == '{':
+            if init or buf.rstrip().endswith(('=', ',')):
+                init += 1               # aggregate initializer, keep reading
+                buf += ' '
+                continue
+            depth += 1
+            heads.append(' '.join(buf.split()))
+            buf, start = '', line
+            continue
+        if ch == '}':
+            if init:
+                init -= 1
+                buf += ' '
+                continue
+            depth = max(0, depth - 1)
+            typetail = bool(re.search(r'\btypedef\b',
+                                      heads.pop() if heads else ''))
+            buf, start = '', line
+            continue
+        if ch == ';' and not init:
+            head = ' '.join(buf.split())
+            if head and not typetail:
+                yield start, head, depth
+            typetail = False
+            buf, start = '', line
+            continue
+        if not buf.strip():
+            start = line
+        buf += ch
+
+
+IS_FUNC = re.compile(r'\([^)]*\)\s*$')
+IS_FUNC_PTR = re.compile(r'\(\s*\*')
+SKIPPABLE = re.compile(r'\b(typedef|extern)\b')
+IS_CONST = re.compile(r'\bconst\b')
+IS_TAG_ONLY = re.compile(r'^(struct|union|enum)\s+\w+$')
+
+
+def mutable(head, depth):
+    if SKIPPABLE.search(head) or IS_CONST.search(head):
+        return False
+    if depth and not head.startswith('static'):
+        return False        # an ordinary local lives on the stack
+    if IS_TAG_ONLY.match(head):
+        return False
+    if IS_FUNC.search(head) and not IS_FUNC_PTR.search(head):
+        return False        # prototype or definition head
+    return bool(re.search(r'\w', head))
+
+
+def sources_of(module, root):
+    """The module's C sources.  Hand-written assembler is not parsed here --
+    its storage is explicit, and `DS`/`DC` in a CSECT is visible on sight."""
+    files = []
+    for pattern in module.get('sources', []):
+        files += glob.glob(os.path.join(root, pattern))
+    dropped = set()
+    for pattern in module.get('exclude', []):
+        dropped |= set(glob.glob(os.path.join(root, pattern)))
+    return sorted(f for f in set(files) - dropped if f.endswith('.c'))
+
+
+def main(argv):
+    toml = argv[1] if len(argv) > 1 else 'project.toml'
+    root = os.path.dirname(os.path.abspath(toml)) or '.'
+    with open(toml, 'rb') as fh:
+        project = tomllib.load(fh)
+
+    findings = []
+    checked = 0
+    for module in project.get('module', []):
+        if module.get('ac', 0) != 1:
+            continue
+        for path in sources_of(module, root):
+            checked += 1
+            src = strip_noise(open(path, encoding='utf-8',
+                                   errors='replace').read())
+            for line, head, depth in declarations(src):
+                if mutable(head, depth):
+                    findings.append((module['name'],
+                                     os.path.relpath(path, root), line, head))
+
+    if not findings:
+        print(f"check-module-data: {checked} sources clean "
+              f"(no writable file-scope data in AC(1) modules)")
+        return 0
+
+    print("check-module-data: writable file-scope data in an AC(1) module\n")
+    for name, path, line, head in findings:
+        print(f"  {path}:{line}: {head[:100]}   [{name}]")
+    print("\nFetched from an APF-authorized library these modules land in "
+          "key-0 storage;\na key-8 store into them abends S0C4 (issue #101). "
+          "Move the value into\nftpd_server (published through the GRT -- see "
+          "ftpd_log_anchor), onto the\nheap, or into CSA behind a key-0 window "
+          "-- or make it const.")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Fixes #101.

## What happens

FTPD is link-edited `AC(1)`. Fetched from an **APF-authorized** library the job step is already authorized when program fetch runs, so MVS obtains the job pack area in **subpool 252, key 0** — authorized code must not be patchable by problem-key code. The STC runs problem state key 8, so any store into the module's own storage is a protection exception.

FTPD's first such store was the *first statement of `main()`*, which is why the reported JESMSGLG is one line:

```
12.34.30 STC 1124  IEF450I FTPD FTPD - ABEND S0C4 U0000 - TIME=12.34.30
```

No `FTPD000I`, no banner — the abend lands ahead of the first WTO and long before `clib_apf_setup()`. The SVC 244 route is unaffected: it sets `JSCBAUTH` *after* the fetch and cannot relabel storage program fetch already allocated, which is why a stock TK4-/TK5 never sees this.

Confirmed at assembler level. `cc370 -S` on the pre-fix `src/ftpd.c`:

```
* X-var ftpd_server
         ENTRY FTPD@SER
FTPD@SER EQU   *
         DC    F'0'
...
         L     2,=A(FTPD@SER)
         ST    4,0(2)              <-- the S0C4; R4 holds &server
         LA    1,88(,13)
         L     15,=V(@@GTCOM)      <-- __gtcom(), still before any WTO
```

## One correction to the issue

The issue reads "`ftpd_server` is `extern` in `include/ftpd.h:182` with ~25 references across three files, so threading it through parameters is the expensive option." That count is of `ftpd_server_t`, the **type**. The pointer itself is written once and **never read**:

```
src/ftpd.c:28:ftpd_server_t *ftpd_server = NULL;
src/ftpd.c:53:    ftpd_server = &server;
include/ftpd.h:182:extern ftpd_server_t *ftpd_server;
```

So the store that kills FTPD is a deletion, not a migration. The GRT anchor is still here — but it is load-bearing for the log/trace state, not for this.

## Changes

- **`ftpd_server` deleted.** The server is published in `grt->grtapp1` as a dump anchor (no code reads it), matching httpd's `grtapp1 = httpd`.
- **Log level and trace ring state move into `struct ftpd_server`** — a `main()` local, hence key 8 — published through `grt->grtapp2` by `ftpd_log_anchor()`. The eleven-function API in `ftpd#log.h` is unchanged, so the 84 `ftpd_log()`/`ftpd_trace()` call sites are untouched. `ftpd#log.c` gains `clibgrt.h` and stays off `ftpd.h`: it has no business with sockets, RACF or the thread manager.
- **`ftpd#xlt.c` tables and pointers become `const`.** Read-only today, but a codepage switch assigning `asc2ebc` is the same bug — it is what killed HTTPD in `http_xlate_init` (mvslovers/httpd#197). The **pointer shape is kept deliberately**: libc370 (`src/dyn75/asc2ebc.c`) and httpd export the same names as `unsigned char *`, and an array here would silently become garbage to anything declaring them the usual way. Nothing in libc370 references them today — both `extern`s in `@@75gabn.c` / `@@75ghba.c` are unused — but the name is ecosystem-wide.
- **`tools/check-module-data.py`** (from mvslovers/ufsd#66, which found this) rejects mutable file-scope data and function-local statics in `AC(1)` modules, as its own CI job. Docstring and failure message point at ftpd's anchor rather than `UFSD_STC`.
- Docs: an APF section in `doc/installation.md` explaining why the two authorization routes differ in storage key, a troubleshooting row for the bare `S0C4`, and the constraint in `CLAUDE.md`.

## Why the GRT works from a worker thread

The one assumption the design rests on, checked rather than assumed. `CTHREAD`, the subtask driver in `libc370/asm/@@crt1.asm`, calls `@@CRTSET` — not `@@GRTSET`. `@@CRTSET` walks the PPA for the **mother task's** CLIBCRT (`TCBOTC`) and copies its `crtgrt`, so the GRT is one per process and inherited transitively: main → thdmgr dispatch thread → session workers. Independently, `cthread_create_ex()` fails a thread create outright when `__grtget()` returns NULL, so every level that successfully creates threads demonstrably has it.

Had this not held, `ftpd_trace()` from a worker would have become a **silent** no-op — trace enabled, `TRACE DUMP` showing only main's entries, nothing in error.

## Two things a reviewer will ask about the anchor

**Who else owns `grtapp1`/`grtapp2`.** Both are free here, checked beyond ftpd's own sources: `grep -rn grtapp` finds nothing in ufsd's `client/` (libufs is linked into FTPD and is designed to be linked into arbitrary consumers, so it is the one that could plausibly have claimed a slot) and nothing in libc370. httpd uses both, but httpd is a different address space. A collision would have been silent in both directions — trace going dead, or UFS commands failing as if UFSD were down.

**The PPA lock.** `__grtget()` → `__crtget()` takes a *shared* PPA lock (`lock(ppa,1)`), so `ftpd_log()` and `ftpd_trace()` now take one where they read a static before. That is not new work on these paths: `stdout` is `(*(stdio->___gtout()))` → `__grtget()`, so every `printf()` — including the one `ftpd_log()` ends in — already takes it, as does every `errno` access via `__errno()` → `__crtget()`. The marginal cost is one extra shared acquisition on a path that already had at least one, and the two calls that can skip the work are cheap either way: there are exactly 2 `ftpd_log(LOG_DEBUG, ...)` sites and 10 `ftpd_trace()` sites, all per-command or per-connection, none in a per-block transfer loop. Nothing here goes near the exclusive-vs-shared hazard the comment four lines above the diff describes: that one is about `main()` calling `__cibset()` while a thread is starting, which is why the ordering it guards is untouched.

## FTPD008I — which route authorized the STC

Both routes end in an authorized task and neither says a word on its own: `clib_apf_setup()` returns 0 whether it authorized us or found us already authorized, and libc370's diagnostics on that path are commented out. That silence is a good part of why this issue was hard to place — the route is exactly what decides whether the module's own storage is writable — so it now goes in the startup log next to the version banner:

```
FTPD008I AUTHORIZED BY LIBRARY (MODULE KEY 0)     APF list entry
FTPD008I AUTHORIZED BY SVC (MODULE KEY 8)         SVC 244, from RAKF
```

`__isauth()` (one TESTAUTH, no supervisor state) is asked *before* `clib_apf_setup()`, since that call destroys the distinction. The key is inferred from the route rather than measured — an authorized job step has its module fetched key 0, an unauthorized one key 8, and SVC 244 arrives too late to change either — and the installation guide says so, so nobody reads it as an ISK result.

Where authorization fails outright, `FTPD003W` already carries that and `FTPD008I` stays out of the way: one line about authorization per start, always. This is FTPD's counterpart to `UFSD007I` (mvslovers/ufsd#66).

## One latent bug fixed on the way past

`ftpd_trace_enable(1)` set `trace_on` and *then* called `ftpd_trace_init()`, which resets it — so `TRACE ON` on an unallocated ring answered `FTPD080I TRACE ENABLED` with tracing off. Unreachable today because `initialize()` allocates the ring at startup; now allocate-then-enable, so it stays correct if that changes.

## Exposure audit

**FTPD's own module:** the guard is clean across all 15 sources, and it is only a text proxy — it cannot tell a `const` pointer from a pointer to const. The real check is `cc370 -S`. Post-fix, `ftpd.c` has no X-var at all, `ftpd#log.c` has one `=A(@V1)` and it is a read of `level_names[]`, and `ftpd#xlt.c`'s `ASC2EBC`/`EBC2ASC` are `DC A(@Vn)` address constants resolved at load time with no runtime store. In the four `ftpd_xlat_*` loops the only store is `STC 2,0(15,3)` into the caller's buffer.

**libufs.a**, linked into FTPD and not covered by either repo's CI: scanned with this same detector, `client/libufs.c` has no module-resident data.

**libc370**, also linked in and out of reach of the guard. Its module-resident statics are real, so rather than inherit ufsd#66's hand audit I checked which members are actually in `build/FTPD` (ESD names, cp037):

| Member | Module data | In FTPD | Verdict |
|--------|-------------|---------|---------|
| `STRTOK` | `static_old` | yes | uses `crt->crtstrtk` when a CRT exists; the static is the no-CRT fallback |
| `@@ERRNO` | `static_errno` | yes | same shape — `crt->crterrno` |
| `MALLOC` | `__lastsup` | yes | inside `#if USE_MEMMGR`, which is off — `__LASTSUP` is not in the module |
| `@@PERM`, `@@STDOUT` | `FILE __perm[3]` | **no** | `stdout` resolves via `@@GTOUT` → `grt->grtout`, on the heap |
| `@@USEREX` | `__userex[]` | **no** | no `atexit()` |
| `ISBUF`, `TOUPPER` | `__isbufR[]`, `__toupR[]` + pointers | yes | tables and their pointers are never written after fetch |
| `@@75VECT`, `ASCTIME`, `PERROR`, `SETLOCAL`, `STRFTIME`, `OSXCALC` | various | **no** | not linked |

So nothing on FTPD's paths stores into libc370's module storage either.

## Verification

- `make` clean (`-Wall -Werror`), `make test-host` 72/72 assertions.
- Guard clean on the fixed tree, and it still reports all 13 pre-fix sites when pointed at a `git archive` of HEAD~1 — so the CI job would have caught this.
- The `cc370 -S` scan above, before and after.
- **Not verified on MVS.** Nothing reproduces key-0 protection off-target: that needs `/S FTPD` with an APF-authorized `FTPD.LINKLIB` reaching `FTPD001I`. The path worth exercising there is the console trace — `/F FTPD,TRACE ON`, a transfer, `/F FTPD,TRACE DUMP` — which has no automated coverage in either direction and is also the empirical answer to the GRT-inheritance question above.

## Follow-up, not in scope here

`tools/check-module-data.py` now exists twice, here and in ufsd, and httpd needs it too (mvslovers/httpd#197 is the same defect). Its natural home is mbt, where the reusable build workflow would give every consumer the job without a copy. Worth a separate issue against mbt.