### PR TITLE
Sweep every stale socket on the port, and only when the bind says so

### DIFF
--- a/include/ftpd#adr.h
+++ b/include/ftpd#adr.h
@@ -41,4 +41,17 @@
 int ftpd_adr_parse(const char *value, char *out, unsigned *addr)
                                                             asm("FTPADRPA");
 
+/*
+** Would a socket already bound to `bound` keep a bind to `want` from
+** succeeding, both on the same port and both in host byte order?
+**
+** 0 (INADDR_ANY, i.e. SRVBIND=ANY) means every interface, so it collides
+** with anything on that port in either direction.  Two different specific
+** addresses do not collide -- they are different interfaces, and a listener
+** on one leaves the port free on the other.
+**
+** Returns non-zero when they collide.
+*/
+int ftpd_adr_conflicts(unsigned bound, unsigned want)        asm("FTPADRCF");
+
 #endif /* FTPD_ADR_H */

--- a/src/ftpd#adr.c
+++ b/src/ftpd#adr.c
@@ -94,3 +94,12 @@ ftpd_adr_parse(const char *value, char *out, unsigned *addr)
 
     return FTPD_ADR_OK;
 }
+
+/* --------------------------------------------------------------------
+** Do two bind addresses on the same port collide?  See ftpd#adr.h.
+** ----------------------------------------------------------------- */
+int
+ftpd_adr_conflicts(unsigned bound, unsigned want)
+{
+    return bound == 0 || want == 0 || bound == want;
+}

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -29,6 +29,7 @@ ftpd_server_t *ftpd_server = NULL;
 
 /* Forward declarations */
 static int  socket_thread(void *arg1, void *arg2);
+static int  close_stale_port(ftpd_server_t *server, int own, unsigned want);
 static int  initialize(ftpd_server_t *server);
 static void terminate(ftpd_server_t *server);
 
@@ -299,6 +300,82 @@ initialize(ftpd_server_t *server)
 /* ====================================================================
 ** Socket thread -- listener, accept loop
 ** ================================================================= */
+
+/* --------------------------------------------------------------------
+** Close every socket still sitting on our listen port.
+**
+** The X'75' socket table lives in Hercules and is global to the whole
+** emulator -- it is not per address space, and a new STC does not inherit
+** anything from a prior run.  That is precisely why getsockname() over
+** socket numbers can see what an FTPD that ended without closing its
+** sockets left behind: the listener AND every connection it had accepted,
+** all of them on the same local port, each one holding it.  Closing the
+** first match is almost never enough, so this closes them all (issue #109).
+**
+** It is also why this has to be careful.  The startup ENQ FTPD.PORT.nnnnn
+** rules out a second live FTPD on this port -- and nothing more.  A live
+** listener on this port that is NOT an FTPD loses its socket here, because
+** the socket table says nothing about who owns an entry and there is no way
+** to tell dead from alive through it.  That is the price of the sweep; it
+** is bounded by running only after our own bind() failed with EADDRINUSE,
+** so a normal start never touches a foreign socket.
+**
+** own  -- the caller's own descriptor, skipped.  This used to run before
+**         socket() had been called at all; it now runs with a live socket
+**         the caller is about to bind, and a failed bind() may still leave
+**         that descriptor in the table carrying a local port.  Closing it
+**         would leave the caller binding a closed socket.
+** want -- the address we are binding, host byte order, 0 for ANY.
+**
+** Returns the number of sockets closed.
+** ----------------------------------------------------------------- */
+static int
+close_stale_port(ftpd_server_t *server, int own, unsigned want)
+{
+    struct sockaddr sa;
+    struct sockaddr_in *sin;
+    unsigned bound;
+    int salen;
+    int si;
+    int closed = 0;
+
+    for (si = 1; si < FD_SETSIZE; si++) {
+        if (si == own)
+            continue;
+
+        salen = sizeof(sa);
+        if (getsockname(si, &sa, &salen) != 0)
+            continue;
+
+        sin = (struct sockaddr_in *)&sa;
+        if (sin->sin_port != htons(server->config.port))
+            continue;
+
+        /* Right port, wrong interface: with SRVBIND naming one address, a
+        ** socket on a different one cannot be what made our bind fail, so
+        ** it is not ours to close. */
+        bound = ntohl(sin->sin_addr.s_addr);
+        if (!ftpd_adr_conflicts(bound, want))
+            continue;
+
+        ftpd_log_wto("FTPD053I CLOSING STALE SOCKET %d ON %u.%u.%u.%u "
+                     "PORT %d", si,
+                     (bound >> 24) & 0xFF, (bound >> 16) & 0xFF,
+                     (bound >>  8) & 0xFF,  bound        & 0xFF,
+                     server->config.port);
+        closesocket(si);
+        closed++;
+    }
+
+    if (closed > 1) {
+        /* The per-socket lines scroll; the operator reads this one. */
+        ftpd_log_wto("FTPD053I %d STALE SOCKETS CLOSED ON PORT %d",
+                     closed, server->config.port);
+    }
+
+    return closed;
+}
+
 static int
 socket_thread(void *arg1, void *arg2)
 {
@@ -308,6 +385,7 @@ socket_thread(void *arg1, void *arg2)
     int len;
     int sock;
     int rc;
+    int err;
     unsigned bindaddr;
     ftpd_session_t *sess;
 
@@ -342,47 +420,44 @@ socket_thread(void *arg1, void *arg2)
     }
     saddr.sin_addr.s_addr = htonl(bindaddr);
 
-    /* Close any stale socket left over from a previous instance that
-    ** did not shut down cleanly.  On MVS the socket fd table is
-    ** per-address-space, so a new STC inherits fds from a prior run
-    ** of the same jobname.  Iterate all fds, check with getsockname
-    ** whether any is bound to our port, and close it.  This avoids
-    ** EADDRINUSE on bind() (same technique as HTTPD).
+    /* Bind first.  The stale-socket sweep below is a last resort and only
+    ** runs when the bind actually failed with EADDRINUSE -- it used to run
+    ** unconditionally in front of every bind, where it could close a socket
+    ** that belongs to something alive on that port for no gain at all
+    ** (issue #109).
+    **
+    ** errno is captured immediately after each bind(): the sweep issues
+    ** getsockname() and closesocket(), and either clobbers it before
+    ** FTPD051E below gets to report it.
     */
-    {
-        int si;
-        int salen;
-        struct sockaddr sa;
-        struct sockaddr_in *sin;
-        for (si = 1; si < FD_SETSIZE; si++) {
-            salen = sizeof(sa);
-            if (getsockname(si, &sa, &salen) == 0) {
-                sin = (struct sockaddr_in *)&sa;
-                if (sin->sin_port == htons(server->config.port)) {
-                    ftpd_log_wto("FTPD053I CLOSING STALE SOCKET %d "
-                                 "ON PORT %d", si, server->config.port);
-                    closesocket(si);
-                    __asm__("STIMER WAIT,BINTVL==F'200'");
-                    break;
-                }
-            }
+    rc  = bind(sock, &saddr, sizeof(saddr));
+    err = (rc < 0) ? errno : 0;
+
+    if (rc < 0 && err == EADDRINUSE) {
+        if (close_stale_port(server, sock, bindaddr) > 0) {
+            /* Give the closes a moment to reach the host stack, then retry
+            ** at once -- the 10s wait below is the fallback, not the first
+            ** resort.  A start that recovers here reports no bind failure
+            ** at all: the FTPD053I lines and FTPD054I tell the story, and an
+            ** E-message in front of a successful start only alarms. */
+            __asm__("STIMER WAIT,BINTVL==F'200'");
+            rc  = bind(sock, &saddr, sizeof(saddr));
+            err = (rc < 0) ? errno : 0;
         }
     }
 
-    if (bind(sock, &saddr, sizeof(saddr)) < 0) {
-        int err = errno;
+    if (rc < 0) {
         ftpd_log_wto("FTPD051E BIND() FAILED ON %s PORT %d, ERRNO=%d",
                      server->config.bind_ip, server->config.port, err);
-        if (err == EADDRINUSE) {
-            ftpd_log_wto("FTPD051I EADDRINUSE, RETRYING IN 10S");
-            __asm__("STIMER WAIT,BINTVL==F'1000'");
-            if (bind(sock, &saddr, sizeof(saddr)) < 0) {
-                ftpd_log_wto("FTPD051E BIND() RETRY FAILED, ERRNO=%d",
-                             errno);
-                closesocket(sock);
-                return 8;
-            }
-        } else {
+        if (err != EADDRINUSE) {
+            closesocket(sock);
+            return 8;
+        }
+
+        ftpd_log_wto("FTPD051I EADDRINUSE, RETRYING IN 10S");
+        __asm__("STIMER WAIT,BINTVL==F'1000'");
+        if (bind(sock, &saddr, sizeof(saddr)) < 0) {
+            ftpd_log_wto("FTPD051E BIND() RETRY FAILED, ERRNO=%d", errno);
             closesocket(sock);
             return 8;
         }

--- a/test/tstadr.c
+++ b/test/tstadr.c
@@ -121,5 +121,20 @@ main(void)
           addr == QUAD(10, 20, 30, 40),
           "the binary alone can be requested");
 
+    /* --- ftpd_adr_conflicts(): which leftover sockets the stale-port
+    ** sweep may close (#109).  Getting this wrong either leaves the port
+    ** occupied or closes a socket on an interface we never asked for. --- */
+    CHECK(ftpd_adr_conflicts(0u, 0u), "ANY over ANY conflicts");
+    CHECK(ftpd_adr_conflicts(QUAD(10, 1, 2, 3), QUAD(10, 1, 2, 3)),
+          "the same address conflicts with itself");
+    CHECK(ftpd_adr_conflicts(0u, QUAD(10, 1, 2, 3)),
+          "a socket on ANY blocks a bind to one interface");
+    CHECK(ftpd_adr_conflicts(QUAD(10, 1, 2, 3), 0u),
+          "a socket on one interface blocks a bind to ANY");
+    CHECK(!ftpd_adr_conflicts(QUAD(10, 1, 2, 3), QUAD(10, 1, 2, 4)),
+          "two different interfaces do not conflict -- leave that one alone");
+    CHECK(!ftpd_adr_conflicts(QUAD(127, 0, 0, 1), QUAD(192, 168, 0, 1)),
+          "loopback does not block a bind to a real interface");
+
     return mbt_test_summary("TSTADR");
 }


### PR DESCRIPTION
Closes #109.

The stale-port sweep in `socket_thread()` stopped at the first match and ran in
front of every bind, whether or not the bind would have succeeded. Both are
fixed; the misleading comment above it is replaced with what the socket table
actually is.

## What changed

**Bind first, sweep only on `EADDRINUSE`.** The sweep is a recovery step for a
port that is demonstrably blocked, not something a healthy start walks through.
It used to run before every bind, where the only thing it could do was close a
socket belonging to something alive on that port.

**Close every match.** A dead FTPD leaves the listener *and* every connection it
had accepted -- an accepted socket's local address is the listen port too, so
`getsockname()` matches it -- and each one holds the port. One `FTPD053I` per
socket, plus a summary line from two upwards, then one 2 second settle (not per
socket) and an immediate rebind. The 10 second retry stays as the fallback.

**No bind failure reported on a start that recovers.** `FTPD051E` moved behind
the sweep, so a successful recovery shows the `FTPD053I` lines and `FTPD054I` and
nothing alarming in front of them. `errno` is captured immediately after each
`bind()`, since `getsockname()` and `closesocket()` in the sweep sit between the
failure and the message reporting it.

**The caller's own descriptor is skipped.** This used to run before `socket()`
had been called; it now runs with a live socket the caller is about to bind, and
a failed `bind()` may still leave that descriptor in the table carrying a local
port.

**The bound address is compared, not just the port.** `SRVBIND` can name one
interface (#76), and a leftover socket on a different one cannot be what made our
bind fail. `INADDR_ANY` collides in both directions. The rule is stated once in
`ftpd_adr_conflicts()` (`ftpd#adr.c`) so it can be tested.

**The comment.** It claimed the fd table is per address space and that a new STC
inherits fds from a prior run of the same jobname. Neither is true: the X'75'
table lives in Hercules, global to the emulator. That is why a dead STC's
leftovers are reachable at all, and why the sweep has to be bounded. What bounds
it is the ENQ `FTPD.PORT.nnnnn` (no second FTPD on this port) plus `EADDRINUSE`
(the port really is blocked). Beyond that it stays indiscriminate, because the
table exposes no owner -- a live listener on this port that is *not* an FTPD does
lose its socket. That boundary is now written into the code rather than implied.

## Relation to HTTPD

Same defect, and deliberately the same shape as the fix mvslovers/httpd#224 just
merged (`mvslovers/httpd@2f2c41c`): bind first, sweep on `EADDRINUSE` only, close
all, skip own descriptor, 2 second settle, existing retry as fallback, `errno`
captured early.

Two FTPD-only additions. The address comparison has no HTTPD counterpart --
`do_bind()` there binds `INADDR_ANY` unconditionally, so there is nothing to
compare. And the summary line, which HTTPD does not have.

`htons()` here versus HTTPD's bare `in->sin_port == port` is not a difference:
libc370 defines `htons`/`ntohl` as `(x)` on big-endian S/370.

## Verification

Host: `make` clean, `make test-host` 78/78 (TSTADR 35, six of them new for
`ftpd_adr_conflicts()`). Note the project `cflags` in `project.toml` carry
neither `-Wall` nor `-Werror`, contrary to the root CLAUDE.md -- CI does not
enforce them. Both changed sources were compiled by hand with `-Wall -Werror`,
clean.

**Run on MVS (mvsdev, MVS/CE, 2026-08-22.)** Throwaway STC on port 2122 from the
mbt staging library, so the live FTPD on 2121 and `FTPD.LINKLIB` were untouched.
Same scenario twice, once against each build: start, connect 3 clients
(`FTPD015I ACTIVE SESSIONS: 3 / 10`), `C FTPDT`, restart.

The leak was confirmed independently before each restart -- address space gone
from `D A,L`, yet a TCP connect to 2122 still succeeded with no banner (listener
alive in Hercules, nothing in MVS accepting) and all three accepted connections
still `ESTABLISHED` in host `netstat`. Four stale sockets, not one.

With the fix (`179cbac`):

```
FTPD053I CLOSING STALE SOCKET 3 ON 192.168.0.233 PORT 2122
FTPD053I CLOSING STALE SOCKET 4 ON 0.0.0.0 PORT 2122
FTPD053I CLOSING STALE SOCKET 5 ON 192.168.0.233 PORT 2122
FTPD053I CLOSING STALE SOCKET 6 ON 192.168.0.233 PORT 2122
FTPD053I 4 STALE SOCKETS CLOSED ON PORT 2122
FTPD054I LISTENING ON ANY PORT 2122
```

Under a second, no `FTPD051E`, no `FTPD051I EADDRINUSE, RETRYING IN 10S`.
Socket 4 is the listener on `0.0.0.0` (SRVBIND=ANY); 3, 5 and 6 are the accepted
connections on the interface address -- so `getsockname()` does fill `sin_addr`
for another address space's sockets. A first start on a free port swept nothing.

Without the fix (`c63024d`, the current `FTPD.LINKLIB`), identical scenario:

```
FTPD053I CLOSING STALE SOCKET 3 ON PORT 2122
FTPD051E BIND() FAILED ON ANY PORT 2122, ERRNO=48
FTPD051I EADDRINUSE, RETRYING IN 10S
FTPD051E BIND() RETRY FAILED, ERRNO=48
```

It closed one socket -- an accepted connection, not the listener -- then `break`,
and never listened at all. Note the first match is not the listener, which is
what makes stopping at it useless.

Restarting the fixed build afterwards swept exactly the three sockets the old
one had left (`4`, `5`, `6`) and came up. `/P` then left 2122 refusing
connections, so a clean shutdown closes the listener properly.

**Not exercised on MVS:** `ftpd_adr_conflicts()` only ran with `want == 0`
(SRVBIND=ANY), where everything on the port collides. The specific-interface
branch -- skipping a socket bound to a different address -- is covered by TSTADR
only.

Test STC proc and config data set were deleted afterwards; port 2122 refuses
connections and the live FTPD on 2121 answers normally.
