### PR TITLE
Configurable bind retries -- and the wait loops that never waited

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -371,6 +371,10 @@ DEFVOLUME=PUB001
 - `SSLPROXY=YES` is only for a TLS-terminating proxy in front of FTPD. Run bare
   it promises clients a confidentiality it does not deliver; the member's own
   comments spell this out.
+- `BINDTRIES`/`BINDWAIT` (both 1–100, both default 10) decide how long FTPD
+  keeps trying a listener port it cannot have yet — a port still held, or a
+  stack that is not up. Giving up ends the started task, so raise `BINDTRIES`
+  if `/S FTPD` runs early in an IPL.
 
 A `#` in the first non-blank column comments a line out — it has to be first,
 because a `#` anywhere else is data.

--- a/include/ftpd#cfg.h
+++ b/include/ftpd#cfg.h
@@ -44,6 +44,14 @@ typedef struct ftpd_config {
                                     ** connect to                     */
     int             pasv_lo;        /* PASV port range low           */
     int             pasv_hi;        /* PASV port range high          */
+    int             bind_tries;     /* BINDTRIES: how many times to
+                                    ** retry a bind() that failed for
+                                    ** a reason waiting can fix       */
+    int             bind_wait;      /* BINDWAIT: seconds between those
+                                    ** retries.  Both matter more since
+                                    ** a bind that never succeeds ends
+                                    ** the STC (#111) instead of
+                                    ** leaving it idle                */
     /* Limits */
     int             max_sessions;   /* max concurrent sessions       */
     int             idle_timeout;   /* idle timeout in seconds       */

--- a/include/ftpd.h
+++ b/include/ftpd.h
@@ -150,7 +150,12 @@ struct ftpd_server {
 #define FTPD_EYE    "*FTPD*"
 
     /* Server flags */
-    unsigned        flags;
+    /* volatile: written by one TCB and polled by another.  The socket
+    ** thread's bind retry watches flags for a /P, main's event loop
+    ** watches it for shutdown, and main watches listen_sock for the
+    ** listener coming up.  Without it cc370 -O1 hoists the load out of
+    ** the polling loop and the poller never sees the change (#113). */
+    volatile unsigned flags;
 #define FTPD_ACTIVE         0x01    /* server is running             */
 #define FTPD_QUIESCE        0x02    /* shutdown in progress          */
 
@@ -171,7 +176,7 @@ struct ftpd_server {
                                     ** identity windows (ftpd#aut.c).
                                     ** Lives in the server struct so it
                                     ** is one anchor per address space  */
-    int             listen_sock;    /* listening socket fd            */
+    volatile int    listen_sock;    /* listening socket fd; see flags */
     CTHDMGR         *mgr;          /* thread manager                */
     CTHDTASK        *sock_task;    /* socket listener thread         */
     unsigned        wakeup_ecb;    /* posted to break main WAIT      */

--- a/samplib/ftpdprm0
+++ b/samplib/ftpdprm0
@@ -23,6 +23,19 @@ SRVBIND=ANY
 #
 PASVPORTS=22000-22200
 #
+# A bind() that fails for a reason waiting can fix -- the port still held
+# by something, or the stack not up yet at IPL -- is retried BINDTRIES
+# times, BINDWAIT seconds apart.  Both 1-100, both default 10, so FTPD
+# waits up to 100 seconds before giving up.
+#
+# Giving up ends the started task (FTPD056E): an FTPD that cannot listen
+# has nothing left to do, and no console command re-tries the bind.  So
+# these two decide how much transient trouble a start survives.  Raise
+# BINDTRIES where FTPD is started before TCP/IP is reliably up.
+#
+BINDTRIES=10
+BINDWAIT=10
+#
 # PASVBIND is where the passive listener binds, PASVADR is what the
 # client is told to connect to -- they are only the same by default.
 # ANY (the default) binds every address of the host, as before.

--- a/src/ftpd#cfg.c
+++ b/src/ftpd#cfg.c
@@ -30,6 +30,9 @@ ftpdcfg_defaults(ftpd_config_t *cfg)
     strcpy(cfg->pasv_bind, "ANY");  /* bind every address, as before */
     cfg->pasv_lo = 22000;
     cfg->pasv_hi = 22200;
+    cfg->bind_tries = 10;           /* HTTPD's defaults: up to 100s of
+                                    ** patience before the STC ends   */
+    cfg->bind_wait = 10;
     /* Limits */
     cfg->max_sessions = 10;
     cfg->idle_timeout = 300;
@@ -151,6 +154,31 @@ parse_keyvalue(ftpd_config_t *cfg, const char *key, const char *value)
             strcpy(cfg->bind_ip, "ANY");
         }
         cfg->bind_ip_alias = (strcmp(key, "SRVIP") == 0);
+    }
+    else if (strcmp(key, "BINDTRIES") == 0 ||
+             strcmp(key, "BINDWAIT") == 0) {
+        /* How long to keep trying a bind that failed for a reason waiting
+        ** can fix.  Clamped rather than refused: an out-of-range value here
+        ** is a typo, and the nearest legal one is what was meant.  100 is
+        ** the ceiling on both, so the longest possible wait is bounded --
+        ** the operator can always /P, the retry checks for it every second.
+        **
+        ** HTTPD spells these BIND_TRIES and BIND_SLEEP with the same
+        ** defaults; the underscore is dropped here because every other FTPD
+        ** keyword is written without one (SRVPORT, PASVPORTS, MAXSESSIONS).
+        */
+        int v = atoi(value);
+
+        if (v < 1 || v > 100) {
+            int clamped = (v < 1) ? 1 : 100;
+            ftpd_log(LOG_WARN, "%s: %s %s out of range 1-100, using %d",
+                     __func__, key, value, clamped);
+            v = clamped;
+        }
+        if (strcmp(key, "BINDTRIES") == 0)
+            cfg->bind_tries = v;
+        else
+            cfg->bind_wait = v;
     }
     else if (strcmp(key, "PASVADR") == 0) {
         /* What the client is told to connect to.  ANY -- and anything
@@ -334,6 +362,8 @@ ftpdcfg_dump(const ftpd_config_t *cfg)
                      ? "ANY (CONTROL CONNECTION)" : cfg->pasv_addr,
                  cfg->pasv_lo, cfg->pasv_hi,
                  cfg->pasv_bind);
+    ftpd_log_wto("FTPD057I   BINDTRIES=%d BINDWAIT=%d",
+                 cfg->bind_tries, cfg->bind_wait);
     ftpd_log_wto("FTPD043I   MAXSESSIONS=%d IDLETIMEOUT=%d",
                  cfg->max_sessions, cfg->idle_timeout);
     ftpd_log_wto("FTPD044I   BANNER=%s", cfg->banner);

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -186,16 +186,26 @@ main(int argc, char **argv)
     ** console read like a healthy start and the contradiction arrived
     ** afterwards, where it is easy to miss.
     **
-    ** The cap is now 20 seconds because that is what it has to outlast --
-    ** sweep, 2s settle, rebind, 10s wait, rebind.  It is only a backstop
-    ** against a socket thread that neither listens nor ends; the normal
-    ** exits are both immediate.  A NULL sock_task (cthread_create_ex
-    ** failed) is the same answer arrived at sooner: nothing will listen.
+    ** The cap is derived, not a constant.  A fixed 20 seconds looked
+    ** generous against a hardcoded 10 second retry and became wrong the
+    ** moment BINDTRIES and BINDWAIT could raise the socket thread's budget
+    ** past it (#113): main hit its cap mid-retry, called the start failed,
+    ** and -- because giving up clears FTPD_ACTIVE -- aborted the very retry
+    ** it was waiting for.  Measured at 10x10s: FTPD056E at 21 seconds, on
+    ** the third of ten tries.  So the cap follows the budget, plus slack
+    ** for the sweep and the settle before it.
+    **
+    ** It is only a backstop against a socket thread that neither listens
+    ** nor ends; both normal exits are immediate.  A NULL sock_task
+    ** (cthread_create_ex failed) is the same answer arrived at sooner:
+    ** nothing will listen.
     */
     {
         int w;
+        int cap = (server.config.bind_tries * server.config.bind_wait + 30)
+                  * 10;             /* tenths of a second */
 
-        for (w = 0; w < 200 && server.listen_sock < 0; w++) {
+        for (w = 0; w < cap && server.listen_sock < 0; w++) {
             if (!server.sock_task ||
                 (server.sock_task->termecb & ECB_POSTED_BIT))
                 break;

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -28,6 +28,8 @@
 /* Forward declarations */
 static int  socket_thread(void *arg1, void *arg2);
 static int  close_stale_port(ftpd_server_t *server, int own, unsigned want);
+static int  bind_retryable(int err);
+static int  bind_wait(ftpd_server_t *server, int secs);
 static int  initialize(ftpd_server_t *server);
 static void terminate(ftpd_server_t *server);
 
@@ -398,6 +400,57 @@ initialize(ftpd_server_t *server)
 ** ================================================================= */
 
 /* --------------------------------------------------------------------
+** Which bind() failures are worth waiting out (issue #113).
+**
+** EADDRINUSE -- something still holds the port.  Once close_stale_port()
+** has run, that is either a live foreign listener or a socket the host
+** stack has not released yet; the second clears on its own.
+**
+** EADDRNOTAVAIL -- the address is not on this host.  Started early in an
+** IPL that means the stack has no address yet, which is exactly what
+** waiting fixes, and it is the case the old EADDRINUSE-only retry missed
+** entirely: measured on MVS, binding an address the host does not have
+** gives errno 49, and the start ended without a single retry (issue #111
+** testing).  With SRVBIND naming a wrong address it never clears, and the
+** retries turn a typo into a slow start that says what is wrong
+** BINDTRIES times over -- a better trade than never waiting at all.
+**
+** Everything else is refused at once.  Waiting does not fix a socket
+** that could not be created or a port a caller is not allowed to have.
+** ----------------------------------------------------------------- */
+static int
+bind_retryable(int err)
+{
+    return err == EADDRINUSE || err == EADDRNOTAVAIL;
+}
+
+/* --------------------------------------------------------------------
+** Sleep `secs` seconds between bind retries, in one second steps, and
+** give up early when the server is being stopped.
+**
+** The step is what makes /P work during a retry run.  BINDTRIES x
+** BINDWAIT can now be 100 seconds; terminate() waits 10 for the socket
+** thread and then says FTPD095W SOCKET THREAD DID NOT TERMINATE, so a
+** thread asleep in one long STIMER would make every longer retry setting
+** worse for the operator than the short one it replaced.
+**
+** Returns 0 when the wait completed, -1 when shutdown was signalled.
+** ----------------------------------------------------------------- */
+static int
+bind_wait(ftpd_server_t *server, int secs)
+{
+    int s;
+
+    for (s = 0; s < secs; s++) {
+        if (!(server->flags & FTPD_ACTIVE))
+            return -1;
+        __asm__("STIMER WAIT,BINTVL==F'100'");
+    }
+
+    return (server->flags & FTPD_ACTIVE) ? 0 : -1;
+}
+
+/* --------------------------------------------------------------------
 ** Close every socket still sitting on our listen port.
 **
 ** The X'75' socket table lives in Hercules and is global to the whole
@@ -543,17 +596,33 @@ socket_thread(void *arg1, void *arg2)
     }
 
     if (rc < 0) {
+        int tries = 0;
+
         ftpd_log_wto("FTPD051E BIND() FAILED ON %s PORT %d, ERRNO=%d",
                      server->config.bind_ip, server->config.port, err);
-        if (err != EADDRINUSE) {
-            closesocket(sock);
-            return 8;
+
+        while (rc < 0 && bind_retryable(err)
+                      && tries < server->config.bind_tries) {
+            tries++;
+            ftpd_log_wto("FTPD051I RETRYING BIND IN %dS (%d OF %d)",
+                         server->config.bind_wait, tries,
+                         server->config.bind_tries);
+            if (bind_wait(server, server->config.bind_wait) < 0) {
+                ftpd_log_wto("FTPD051I BIND RETRY ABANDONED, "
+                             "FTPD IS STOPPING");
+                closesocket(sock);
+                return 8;
+            }
+            rc  = bind(sock, &saddr, sizeof(saddr));
+            err = (rc < 0) ? errno : 0;
         }
 
-        ftpd_log_wto("FTPD051I EADDRINUSE, RETRYING IN 10S");
-        __asm__("STIMER WAIT,BINTVL==F'1000'");
-        if (bind(sock, &saddr, sizeof(saddr)) < 0) {
-            ftpd_log_wto("FTPD051E BIND() RETRY FAILED, ERRNO=%d", errno);
+        if (rc < 0) {
+            /* A non-retryable errno said everything it had to say in the
+            ** FTPD051E above; only a run of retries needs its own verdict. */
+            if (tries)
+                ftpd_log_wto("FTPD051E BIND() STILL FAILING AFTER %d "
+                             "TRIES, ERRNO=%d", tries, err);
             closesocket(sock);
             return 8;
         }

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -209,12 +209,32 @@ main(int argc, char **argv)
             if (!server.sock_task ||
                 (server.sock_task->termecb & ECB_POSTED_BIT))
                 break;
+
+            /* Drain CIBs here as well, not only in the event loop below.
+            ** A bind retry runs for up to BINDTRIES x BINDWAIT seconds and
+            ** main spends all of it in this loop, so an operator's /P used
+            ** to sit unread on the CIB queue until the retries gave up by
+            ** themselves: measured at 10x10s, /P did nothing and the STC
+            ** ran the full 100 seconds.  Reading them here is what makes
+            ** the FTPD_ACTIVE check in bind_wait() mean anything. */
+            while ((cib = __cibget()) != NULL) {
+                ftpd_process_cib(&server, cib);
+                __cibdel(cib);
+            }
+            if (!(server.flags & FTPD_ACTIVE))
+                break;
+
             __asm__("STIMER WAIT,BINTVL==F'10'" : : : "0", "1", "14", "15");
         }
     }
 
     if (server.listen_sock >= 0) {
         ftpd_log_wto("FTPD001I FTPD %s READY", vers);
+    } else if (!(server.flags & FTPD_ACTIVE)) {
+        /* Stopped before the listener came up.  Nothing to announce and
+        ** nothing to complain about: the operator asked for this, the
+        ** socket thread already said it abandoned its retry, and rc stays
+        ** 0 because a /P that worked is not a failed start. */
     } else {
         /* End, rather than sit there.  An FTPD that cannot listen has
         ** nothing left to do: there is no console command that retries the

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -199,7 +199,7 @@ main(int argc, char **argv)
             if (!server.sock_task ||
                 (server.sock_task->termecb & ECB_POSTED_BIT))
                 break;
-            __asm__("STIMER WAIT,BINTVL==F'10'");
+            __asm__("STIMER WAIT,BINTVL==F'10'" : : : "0", "1", "14", "15");
         }
     }
 
@@ -263,7 +263,7 @@ main(int argc, char **argv)
         if (!(server.flags & FTPD_ACTIVE)) break;
 
         /* Sleep 1 second (100 centiseconds), then check again */
-        __asm__("STIMER WAIT,BINTVL==F'100'");
+        __asm__("STIMER WAIT,BINTVL==F'100'" : : : "0", "1", "14", "15");
     }
 
     terminate(&server);
@@ -444,7 +444,7 @@ bind_wait(ftpd_server_t *server, int secs)
     for (s = 0; s < secs; s++) {
         if (!(server->flags & FTPD_ACTIVE))
             return -1;
-        __asm__("STIMER WAIT,BINTVL==F'100'");
+        __asm__("STIMER WAIT,BINTVL==F'100'" : : : "0", "1", "14", "15");
     }
 
     return (server->flags & FTPD_ACTIVE) ? 0 : -1;
@@ -589,7 +589,7 @@ socket_thread(void *arg1, void *arg2)
             ** resort.  A start that recovers here reports no bind failure
             ** at all: the FTPD053I lines and FTPD054I tell the story, and an
             ** E-message in front of a successful start only alarms. */
-            __asm__("STIMER WAIT,BINTVL==F'200'");
+            __asm__("STIMER WAIT,BINTVL==F'200'" : : : "0", "1", "14", "15");
             rc  = bind(sock, &saddr, sizeof(saddr));
             err = (rc < 0) ? errno : 0;
         }
@@ -744,7 +744,7 @@ terminate(ftpd_server_t *server)
                 ftpd_log_wto("FTPD095I WAITING FOR SOCKET THREAD "
                              "TO TERMINATE (%d)", i);
             }
-            __asm__("STIMER WAIT,BINTVL==F'100'");
+            __asm__("STIMER WAIT,BINTVL==F'100'" : : : "0", "1", "14", "15");
         }
         if (!(server->sock_task->termecb & 0x40000000U)) {
             ftpd_log_wto("FTPD095W SOCKET THREAD DID NOT TERMINATE");


### PR DESCRIPTION
Closes #113.

Four commits. The first is the feature that was asked for; the other three are a
latent defect it dragged into the light, and the consequences of fixing it.

**Read the third commit first if you read only one.** It repairs a regression
shipped in #111 that would break the stale-port recovery from #109 on `main`
today.

## 1. Configurable retries, and retrying the right thing

`BINDTRIES` and `BINDWAIT`, both 1–100, both defaulting to 10, so the wait
before giving up goes from 10 seconds to up to 100. Out-of-range values are
clamped rather than refused. The underscore HTTPD uses (`BIND_TRIES`,
`BIND_SLEEP`) is dropped because no other FTPD keyword has one. `FTPD057I`
reports both in the CONFIG dump; sample member and `doc/installation.md` updated.

The more interesting half is *what* gets retried. The old retry ran only for
`EADDRINUSE`, which is not the failure most in need of patience — starting
before the stack has an address fails `EADDRNOTAVAIL`, and FTPD gave up on it
at once. Meanwhile `EADDRINUSE`, the one case that was retried, is now largely
handled by the stale-port sweep (#109) before the retry loop is reached. Both
are retryable now; everything else is still refused immediately.

## 2. The wait loops did not wait

Measured with an instrumented build on MVS: main's loop waiting for the
listener exited after **one** iteration with `listen_sock` still -1, the socket
thread alive and its `termecb` clear — none of its exit conditions true.

Two causes, both visible in `cc370 -S`:

- `__asm__("STIMER WAIT,BINTVL==F'10'")` carried **no clobber list**, so the
  compiler kept `sock_task` in **R15** across the SVC. The next iteration
  tested garbage, found it non-zero, read a "termecb" from it and left. libc370
  writes the same macro as `: : : "0", "1"` for exactly this reason
  (`@@75send.c`, `@@75acce.c`); R14/R15 go on the list here because R15 is
  demonstrably destroyed. All five sites in the file are fixed.
- `listen_sock` and `flags` are written by one TCB and polled by another and
  were not `volatile`, so the load was hoisted out of the loop — the poller
  could never have seen a change even with the registers intact.

**This is a live regression on `main`.** With the wait collapsing to a single
0.1s pass, any start whose bind did not succeed almost immediately was declared
`FTPD056E` and ended — including #109's stale-port recovery, whose sweep, 2s
settle and rebind take far longer than the wait was actually lasting. The #111
tests passed because both cases they covered resolve inside that first pass: an
instant `EADDRNOTAVAIL` failure, and a bind that succeeds at once.

## 3. Then the cap, then the console

With the wait actually waiting, two more things followed:

`main`'s fixed 20 second cap was wrong the moment `BINDTRIES × BINDWAIT` could
exceed it. Measured at 10×10s: `FTPD056E` at 21 seconds, on the third of ten
tries — and because giving up clears `FTPD_ACTIVE`, main aborted the retry it
was waiting for. The cap now follows the configured budget plus slack.

And main spends that whole budget in the wait loop, which did not drain CIBs —
only the event loop after it does. So `/P` sat unread until the retries gave up
on their own: measured at 10×10s, `/P` did nothing and the STC ran the full 100
seconds. The wait loop now reads the console too, which is also what gives the
`FTPD_ACTIVE` check in `bind_wait()` any effect. A start stopped that way
announces neither READY nor `FTPD056E` and returns 0 — a `/P` that worked is not
a failed start.

## Verified on MVS (mvsdev, MVS/CE, 2026-08-22)

Throwaway STC on port 2122; the live FTPD on 2121 and `FTPD.LINKLIB` untouched.

**Retries run, at the configured interval** (`BINDTRIES=3 BINDWAIT=2`,
`SRVBIND` on an address the host does not have):

```
12.31.47 FTPD051E BIND() FAILED ON 10.99.99.99 PORT 2122, ERRNO=49
12.31.47 FTPD051I RETRYING BIND IN 2S (1 OF 3)
12.31.49 FTPD051I RETRYING BIND IN 2S (2 OF 3)
12.31.51 FTPD051I RETRYING BIND IN 2S (3 OF 3)
12.31.53 FTPD051E BIND() STILL FAILING AFTER 3 TRIES, ERRNO=49
12.31.53 FTPD056E FTPD IS NOT LISTENING ON PORT 2122, THIS INSTANCE ENDS
         IEF142I FTPDT FTPDT - STEP WAS EXECUTED - COND CODE 0008
```

errno 49 retried at all is new; the old code ended without a single retry.

**The full budget is honoured** (10×10s): ten tries at exactly ten second
intervals, 12.34.07 → 12.35.47, then the verdict. Before the cap fix this died
at 21 seconds.

**The console answers during a retry run**, past the old cap:

```
12.37.17 FTPD057I   BINDTRIES=10 BINDWAIT=10        (F FTPDT,CONFIG at +23s)
12.37.19 FTPD098I FTPD SHUTTING DOWN                (P FTPDT)
12.37.19 FTPD051I BIND RETRY ABANDONED, FTPD IS STOPPING
12.37.21 IEF404I FTPDT - ENDED
```

Two seconds from `/P` to ended, instead of the remaining ~70.

**#109 stale-port recovery, the case the regression would have broken** — three
clients connected, `C FTPDT`, leak confirmed (connect succeeds, no banner),
restart:

```
12.38.14 FTPD053I CLOSING STALE SOCKET 3 ON 0.0.0.0 PORT 2122
12.38.14 FTPD053I CLOSING STALE SOCKET 5 ON 192.168.0.233 PORT 2122
12.38.14 FTPD053I CLOSING STALE SOCKET 6 ON 192.168.0.233 PORT 2122
12.38.14 FTPD053I CLOSING STALE SOCKET 7 ON 192.168.0.233 PORT 2122
12.38.14 FTPD053I 4 STALE SOCKETS CLOSED ON PORT 2122
12.38.16 FTPD054I LISTENING ON ANY PORT 2122
12.38.16 FTPD001I FTPD 1.0.1-DEV READY
         IEF142I FTPDT FTPDT - STEP WAS EXECUTED - COND CODE 0000
```

Two seconds between the sweep and the listener — the gap main previously
skipped. Banner probe answered, `/P` ended it with COND CODE 0000.

`make test-host` 78/78, `tools/check-module-data.py` clean over 15 sources,
`src/ftpd.c` and `src/ftpd#cfg.c` compiled by hand with `-Wall -Werror` (the
project `cflags` carry neither, so CI does not enforce them).

Test STC proc and config data set deleted afterwards; port 2122 refuses
connections and the live FTPD on 2121 answers normally.

## Worth a follow-up, not done here

`terminate()` tests the same posted bit as a raw `0x40000000U` rather than
`ECB_POSTED_BIT`. And the bare-`__asm__` pattern fixed here exists in other
FTPD sources and across the ecosystem — this PR only covers `src/ftpd.c`.
