### PR TITLE
Name the posted bit in terminate()

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -769,14 +769,14 @@ terminate(ftpd_server_t *server)
 
     if (server->sock_task) {
         int i;
-        for (i = 0; (i < 10) && (!(server->sock_task->termecb & 0x40000000U)); i++) {
+        for (i = 0; (i < 10) && (!(server->sock_task->termecb & ECB_POSTED_BIT)); i++) {
             if (i) {
                 ftpd_log_wto("FTPD095I WAITING FOR SOCKET THREAD "
                              "TO TERMINATE (%d)", i);
             }
             __asm__("STIMER WAIT,BINTVL==F'100'" : : : "0", "1", "14", "15");
         }
-        if (!(server->sock_task->termecb & 0x40000000U)) {
+        if (!(server->sock_task->termecb & ECB_POSTED_BIT)) {
             ftpd_log_wto("FTPD095W SOCKET THREAD DID NOT TERMINATE");
         }
         cthread_delete(&server->sock_task);


### PR DESCRIPTION
The first of the two leftovers noted at the end of #112. The second turned out
not to exist — see below.

## The change

`terminate()` tested the ECB posted bit as a raw `0x40000000U`, twice, while the
wait loop in `main()` a few hundred lines up spells it `ECB_POSTED_BIT`. Same
bit, same struct field, two vocabularies — and the raw one is the harder to grep
for when the question is "where do we check whether the socket thread has ended".

Generated assembler is byte identical before and after (`cc370 -O1 -S`, `cmp`);
`clibecb.h` defines the macro as exactly that constant.

`make` clean, `make test-host` 78/78, `tools/check-module-data.py` clean.

## The other leftover was a false alarm

#112 also said "the bare-`__asm__` pattern fixed here exists in other FTPD
sources — this PR only covers `src/ftpd.c`". That is wrong, and worth correcting
rather than leaving as a standing to-do.

`src/ftpd.c` is the **only** file in the repository containing inline assembler
at all — five `STIMER` sites, all of which already carry
`"0", "1", "14", "15"` from #114:

```
src/ftpd.c:227  src/ftpd.c:296  src/ftpd.c:477  src/ftpd.c:622  src/ftpd.c:777
```

Nothing else in `src/`, `include/` or `asm/` has an `__asm__` beyond the
`SETC '&FUNC'` name markers. So there is no follow-up owed here.

The equivalent sweep in libc370, where the pattern really does recur, is
mvslovers/libc370#134.
